### PR TITLE
fix: Add conditional verbatimModuleSyntax based on Start add-on status

### DIFF
--- a/packages/cta-engine/templates/react/base/tsconfig.json.ejs
+++ b/packages/cta-engine/templates/react/base/tsconfig.json.ejs
@@ -11,7 +11,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": <% if (addOnEnabled['start']) { %>false,  /* Should be turned off when using Start to avoid server bundles leaking into client bundles*/<% } else { %>true,<% } %>
     "noEmit": true,
 
     /* Linting */


### PR DESCRIPTION
`verbatimModuleSyntax`  Should be turned off when using Start to avoid server bundles leaking into client bundles

https://tanstack.com/start/latest/docs/framework/react/build-from-scratch#typescript-configuration

https://github.com/TanStack/router/issues/3401