### PR TITLE
fix(neon): use named import for postgresPlugin

### DIFF
--- a/examples/custom-cli/create-rwsdk/add-ons/neon/assets/neon-vite-plugin.ts
+++ b/examples/custom-cli/create-rwsdk/add-ons/neon/assets/neon-vite-plugin.ts
@@ -1,4 +1,4 @@
-import postgresPlugin from '@neondatabase/vite-plugin-postgres'
+import { postgresPlugin } from '@neondatabase/vite-plugin-postgres'
 
 export default postgresPlugin({
   seed: {

--- a/packages/create/src/frameworks/react/add-ons/neon/assets/neon-vite-plugin.ts
+++ b/packages/create/src/frameworks/react/add-ons/neon/assets/neon-vite-plugin.ts
@@ -1,4 +1,4 @@
-import postgresPlugin from '@neondatabase/vite-plugin-postgres'
+import { postgresPlugin } from '@neondatabase/vite-plugin-postgres'
 
 export default postgresPlugin({
   seed: {


### PR DESCRIPTION
The @neondatabase/vite-plugin-postgres package exports postgresPlugin as a named export, not a default export. This fixes the SyntaxError when running pnpm dev on projects created with the Neon add-on.

Fixes #318