### PR TITLE
feat: add Strapi CMS add-on

### DIFF
--- a/.changeset/blue-dingos-shop.md
+++ b/.changeset/blue-dingos-shop.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/create': patch
+---
+
+Improve the Strapi add-on scaffolding for reliability.
+
+- Remove brittle post-create shell automation that attempted to clone and bootstrap a sibling Strapi server.
+- Fix Strapi article detail routing to use a consistent file-based route path.
+- Update Strapi add-on guidance to document manual/hosted Strapi setup expectations.

--- a/packages/create/src/frameworks/react/add-ons/strapi/README.md
+++ b/packages/create/src/frameworks/react/add-ons/strapi/README.md
@@ -1,14 +1,158 @@
-## Setting up Strapi
+## Strapi CMS Integration
 
-The current setup shows an example of how to use Strapi with an articles collection which is part of the example structure & data.
+This add-on integrates Strapi CMS with your TanStack Start application using the official Strapi Client SDK. The Strapi server is created as a sibling directory during setup.
 
-- Create a local running copy of the strapi admin
+### Features
 
-```bash
-pnpm dlx create-strapi@latest my-strapi-project
-cd my-strapi-project
-pnpm dev
+- Article listing with search and pagination
+- Article detail pages with dynamic block rendering
+- Rich text, quotes, media, and image slider blocks
+- Markdown content rendering with GitHub Flavored Markdown
+- Responsive image handling with error fallbacks
+- URL-based search and pagination (shareable/bookmarkable)
+- Graceful error handling with helpful setup instructions
+
+### Project Structure
+
+```
+parent/
+├── client/                 # TanStack Start frontend (your project name)
+│   ├── src/
+│   │   ├── components/
+│   │   │   ├── blocks/     # Block rendering components
+│   │   │   ├── markdown-content.tsx
+│   │   │   ├── pagination.tsx
+│   │   │   ├── search.tsx
+│   │   │   └── strapi-image.tsx
+│   │   ├── data/
+│   │   │   ├── loaders/    # Server functions
+│   │   │   └── strapi-sdk.ts
+│   │   ├── lib/
+│   │   │   └── strapi-utils.ts
+│   │   ├── routes/demo/
+│   │   │   ├── strapi.tsx              # Articles list
+│   │   │   └── strapi_.$articleId.tsx  # Article detail
+│   │   └── types/
+│   │       └── strapi.ts
+│   ├── .env.local
+│   └── package.json
+└── server/                 # Strapi CMS backend (auto-created)
+    ├── src/api/            # Content types
+    ├── config/             # Strapi configuration
+    └── package.json
 ```
 
-- Login and publish the example articles to see them on the strapi demo page.
-- Set the `VITE_STRAPI_URL` environment variable in your `.env.local`. (For local it should be http://localhost:1337/api)
+### Quick Start
+
+The Strapi server is automatically cloned from the official [Strapi Cloud Template Blog](https://github.com/strapi/strapi-cloud-template-blog).
+
+**1. Install Strapi dependencies:**
+
+```bash
+cd ../server
+npm install    # or pnpm install / yarn install
+```
+
+**2. Start the Strapi server:**
+
+```bash
+npm run develop    # Starts at http://localhost:1337
+```
+
+**3. Create an admin account:**
+
+Open http://localhost:1337/admin and create your first admin user.
+
+**4. Create content:**
+
+In the Strapi admin panel, go to Content Manager > Article and create some articles.
+
+**5. Start your TanStack app (in another terminal):**
+
+```bash
+cd ../client   # or your project name
+npm run dev    # Starts at http://localhost:3000
+```
+
+**6. View the demo:**
+
+Navigate to http://localhost:3000/demo/strapi to see your articles.
+
+### Environment Variables
+
+The following environment variable is pre-configured in `.env.local`:
+
+```bash
+VITE_STRAPI_URL="http://localhost:1337"
+```
+
+For production, update this to your deployed Strapi URL.
+
+### Demo Pages
+
+| URL | Description |
+|-----|-------------|
+| `/demo/strapi` | Articles list with search and pagination |
+| `/demo/strapi/:articleId` | Article detail with block rendering |
+
+### Search and Pagination
+
+- **Search**: Type in the search box to filter articles by title or description
+- **Pagination**: Navigate between pages using the pagination controls
+- **URL State**: Search and page are stored in the URL (`?query=term&page=2`)
+
+### Block Types Supported
+
+| Block | Component | Description |
+|-------|-----------|-------------|
+| `shared.rich-text` | RichText | Markdown content |
+| `shared.quote` | Quote | Blockquote with author |
+| `shared.media` | Media | Single image/video |
+| `shared.slider` | Slider | Image gallery grid |
+
+### Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@strapi/client` | Official Strapi SDK |
+| `react-markdown` | Markdown rendering |
+| `remark-gfm` | GitHub Flavored Markdown |
+| `use-debounce` | Debounced search input |
+
+### Running Both Servers
+
+Open two terminal windows from the parent directory:
+
+**Terminal 1 - Strapi:**
+```bash
+cd server && npm run develop
+```
+
+**Terminal 2 - TanStack Start:**
+```bash
+cd client && npm run dev   # or your project name
+```
+
+### Customization
+
+**Change page size:**
+Edit `src/data/loaders/articles.ts` and modify `PAGE_SIZE`.
+
+**Add new block types:**
+1. Create component in `src/components/blocks/`
+2. Export from `src/components/blocks/index.ts`
+3. Add case to `block-renderer.tsx` switch statement
+4. Update populate in articles loader
+
+**Add new content types:**
+1. Add types to `src/types/strapi.ts`
+2. Create loader in `src/data/loaders/`
+3. Create route in `src/routes/demo/`
+
+### Learn More
+
+- [Strapi Documentation](https://docs.strapi.io/)
+- [Strapi Client SDK](https://www.npmjs.com/package/@strapi/client)
+- [Strapi Cloud Template Blog](https://github.com/strapi/strapi-cloud-template-blog)
+- [TanStack Start Documentation](https://tanstack.com/start/latest)
+- [TanStack Router Search Params](https://tanstack.com/router/latest/docs/framework/react/guide/search-params)

--- a/packages/create/src/frameworks/react/add-ons/strapi/README.md
+++ b/packages/create/src/frameworks/react/add-ons/strapi/README.md
@@ -1,6 +1,6 @@
 ## Strapi CMS Integration
 
-This add-on integrates Strapi CMS with your TanStack Start application using the official Strapi Client SDK. The Strapi server is created as a sibling directory during setup.
+This add-on integrates Strapi CMS with your TanStack Start application using the official Strapi Client SDK.
 
 ### Features
 
@@ -31,12 +31,12 @@ parent/
 │   │   │   └── strapi-utils.ts
 │   │   ├── routes/demo/
 │   │   │   ├── strapi.tsx              # Articles list
-│   │   │   └── strapi_.$articleId.tsx  # Article detail
+│   │   │   └── strapi.$articleId.tsx   # Article detail
 │   │   └── types/
 │   │       └── strapi.ts
 │   ├── .env.local
 │   └── package.json
-└── server/                 # Strapi CMS backend (auto-created)
+└── server/                 # Strapi CMS backend (create manually or use hosted Strapi)
     ├── src/api/            # Content types
     ├── config/             # Strapi configuration
     └── package.json
@@ -44,9 +44,15 @@ parent/
 
 ### Quick Start
 
-The Strapi server is automatically cloned from the official [Strapi Cloud Template Blog](https://github.com/strapi/strapi-cloud-template-blog).
+Create your Strapi project separately (or use an existing hosted Strapi instance), then point this app to it with `VITE_STRAPI_URL`.
 
-**1. Install Strapi dependencies:**
+**1. Set up Strapi:**
+
+Follow the Strapi quick-start guide to create a local project, or use your existing Strapi deployment:
+
+- https://docs.strapi.io/dev-docs/quick-start
+
+If you created a local Strapi project in a sibling `server` directory, continue with:
 
 ```bash
 cd ../server

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/_dot_env.local.append
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/_dot_env.local.append
@@ -1,2 +1,2 @@
 # Strapi configuration
-VITE_STRAPI_URL="http://localhost:1337/api"
+VITE_STRAPI_URL="http://localhost:1337"

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/block-renderer.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/block-renderer.tsx
@@ -1,0 +1,55 @@
+import { RichText } from "./rich-text";
+import { Quote } from "./quote";
+import { Media } from "./media";
+import { Slider } from "./slider";
+
+import type { IRichText } from "./rich-text";
+import type { IQuote } from "./quote";
+import type { IMedia } from "./media";
+import type { ISlider } from "./slider";
+
+// Union type of all block types
+export type Block = IRichText | IQuote | IMedia | ISlider;
+
+interface BlockRendererProps {
+  blocks: Array<Block>;
+}
+
+/**
+ * BlockRenderer - Renders dynamic content blocks from Strapi
+ *
+ * Usage:
+ * ```tsx
+ * <BlockRenderer blocks={article.blocks} />
+ * ```
+ */
+export function BlockRenderer({ blocks }: Readonly<BlockRendererProps>) {
+  if (!blocks || blocks.length === 0) return null;
+
+  const renderBlock = (block: Block) => {
+    switch (block.__component) {
+      case "shared.rich-text":
+        return <RichText {...block} />;
+      case "shared.quote":
+        return <Quote {...block} />;
+      case "shared.media":
+        return <Media {...block} />;
+      case "shared.slider":
+        return <Slider {...block} />;
+      default:
+        // Log unknown block types in development
+        console.warn("Unknown block type:", (block as any).__component);
+        return null;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {blocks.map((block, index) => (
+        <div key={`${block.__component}-${block.id}-${index}`}>
+          {renderBlock(block)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/index.ts
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/index.ts
@@ -1,0 +1,14 @@
+export { BlockRenderer } from "./block-renderer";
+export type { Block } from "./block-renderer";
+
+export { RichText } from "./rich-text";
+export type { IRichText } from "./rich-text";
+
+export { Quote } from "./quote";
+export type { IQuote } from "./quote";
+
+export { Media } from "./media";
+export type { IMedia } from "./media";
+
+export { Slider } from "./slider";
+export type { ISlider } from "./slider";

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/media.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/media.tsx
@@ -1,0 +1,27 @@
+import { StrapiImage } from "@/components/strapi-image";
+import type { TImage } from "@/types/strapi";
+
+export interface IMedia {
+  __component: "shared.media";
+  id: number;
+  file?: TImage;
+}
+
+export function Media({ file }: Readonly<IMedia>) {
+  if (!file) return null;
+
+  return (
+    <figure className="my-8">
+      <StrapiImage
+        src={file.url}
+        alt={file.alternativeText || ""}
+        className="rounded-lg w-full"
+      />
+      {file.alternativeText && (
+        <figcaption className="mt-2 text-center text-sm text-gray-500">
+          {file.alternativeText}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/quote.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/quote.tsx
@@ -1,0 +1,19 @@
+export interface IQuote {
+  __component: "shared.quote";
+  id: number;
+  body: string;
+  title?: string;
+}
+
+export function Quote({ body, title }: Readonly<IQuote>) {
+  return (
+    <blockquote className="border-l-4 border-cyan-400 pl-6 py-4 my-6 bg-slate-800/30 rounded-r-lg">
+      <p className="text-xl italic text-gray-300 leading-relaxed">{body}</p>
+      {title && (
+        <cite className="block mt-4 text-cyan-400 not-italic font-medium">
+          — {title}
+        </cite>
+      )}
+    </blockquote>
+  );
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/rich-text.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/rich-text.tsx
@@ -1,0 +1,11 @@
+import { MarkdownContent } from "@/components/markdown-content";
+
+export interface IRichText {
+  __component: "shared.rich-text";
+  id: number;
+  body: string;
+}
+
+export function RichText({ body }: Readonly<IRichText>) {
+  return <MarkdownContent content={body} />;
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/slider.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/blocks/slider.tsx
@@ -1,0 +1,28 @@
+import { StrapiImage } from "@/components/strapi-image";
+import type { TImage } from "@/types/strapi";
+
+export interface ISlider {
+  __component: "shared.slider";
+  id: number;
+  files?: Array<TImage>;
+}
+
+export function Slider({ files }: Readonly<ISlider>) {
+  if (!files || files.length === 0) return null;
+
+  return (
+    <div className="my-8">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {files.map((file, index) => (
+          <figure key={file.id || index}>
+            <StrapiImage
+              src={file.url}
+              alt={file.alternativeText || ""}
+              className="rounded-lg w-full h-48 object-cover"
+            />
+          </figure>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/markdown-content.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/markdown-content.tsx
@@ -1,0 +1,74 @@
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface MarkdownContentProps {
+  content: string | undefined | null;
+  className?: string;
+}
+
+const styles = {
+  h1: "text-3xl font-bold mb-6 text-white",
+  h2: "text-2xl font-bold mb-4 text-white",
+  h3: "text-xl font-bold mb-3 text-white",
+  p: "mb-4 leading-relaxed text-gray-300",
+  a: "text-cyan-400 hover:underline",
+  ul: "list-disc pl-6 mb-4 space-y-2 text-gray-300",
+  ol: "list-decimal pl-6 mb-4 space-y-2 text-gray-300",
+  li: "leading-relaxed",
+  blockquote: "border-l-4 border-cyan-400 pl-4 italic text-gray-400 my-4",
+  code: "bg-slate-800 px-2 py-1 rounded text-cyan-400 text-sm font-mono",
+  pre: "bg-slate-800 p-4 rounded-lg overflow-x-auto mb-4",
+  table: "w-full border-collapse mb-4",
+  th: "border border-slate-700 p-2 bg-slate-800 text-left text-white",
+  td: "border border-slate-700 p-2 text-gray-300",
+  img: "max-w-full h-auto rounded-lg my-4",
+  hr: "border-slate-700 my-8",
+  strong: "text-white font-semibold",
+};
+
+export function MarkdownContent({ content, className = "" }: MarkdownContentProps) {
+  if (!content) return null;
+
+  return (
+    <div className={`prose prose-invert max-w-none ${className}`}>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => <h1 className={styles.h1}>{children}</h1>,
+          h2: ({ children }) => <h2 className={styles.h2}>{children}</h2>,
+          h3: ({ children }) => <h3 className={styles.h3}>{children}</h3>,
+          p: ({ children }) => <p className={styles.p}>{children}</p>,
+          a: ({ href, children }) => (
+            <a href={href} className={styles.a} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
+          ),
+          ul: ({ children }) => <ul className={styles.ul}>{children}</ul>,
+          ol: ({ children }) => <ol className={styles.ol}>{children}</ol>,
+          li: ({ children }) => <li className={styles.li}>{children}</li>,
+          blockquote: ({ children }) => <blockquote className={styles.blockquote}>{children}</blockquote>,
+          code: ({ className, children }) => {
+            const isCodeBlock = className?.includes("language-");
+            if (isCodeBlock) {
+              return (
+                <pre className={styles.pre}>
+                  <code className="text-sm font-mono text-gray-300">{children}</code>
+                </pre>
+              );
+            }
+            return <code className={styles.code}>{children}</code>;
+          },
+          pre: ({ children }) => <>{children}</>,
+          table: ({ children }) => <table className={styles.table}>{children}</table>,
+          th: ({ children }) => <th className={styles.th}>{children}</th>,
+          td: ({ children }) => <td className={styles.td}>{children}</td>,
+          img: ({ src, alt }) => <img src={src} alt={alt || ""} className={styles.img} />,
+          hr: () => <hr className={styles.hr} />,
+          strong: ({ children }) => <strong className={styles.strong}>{children}</strong>,
+        }}
+      >
+        {content}
+      </Markdown>
+    </div>
+  );
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/pagination.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/pagination.tsx
@@ -1,0 +1,120 @@
+import { useRouter, useSearch } from '@tanstack/react-router'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface PaginationProps {
+  pageCount: number
+  className?: string
+}
+
+export function Pagination({ pageCount, className = '' }: PaginationProps) {
+  const router = useRouter()
+  const search = useSearch({ strict: false })
+  const currentPage = Number((search as any)?.page) || 1
+
+  const handlePageChange = (page: number) => {
+    router.navigate({
+      to: '.',
+      search: (prev) => ({ ...prev, page }),
+      replace: true,
+    })
+  }
+
+  // Generate page numbers to display
+  const getPageNumbers = () => {
+    const pages: Array<number | 'ellipsis'> = []
+    const showEllipsis = pageCount > 7
+
+    if (showEllipsis) {
+      pages.push(1)
+
+      if (currentPage > 3) {
+        pages.push('ellipsis')
+      }
+
+      const start = Math.max(2, currentPage - 1)
+      const end = Math.min(pageCount - 1, currentPage + 1)
+
+      for (let i = start; i <= end; i++) {
+        pages.push(i)
+      }
+
+      if (currentPage < pageCount - 2) {
+        pages.push('ellipsis')
+      }
+
+      if (pageCount > 1) {
+        pages.push(pageCount)
+      }
+    } else {
+      for (let i = 1; i <= pageCount; i++) {
+        pages.push(i)
+      }
+    }
+
+    return pages
+  }
+
+  const pageNumbers = getPageNumbers()
+
+  if (pageCount <= 1) return null
+
+  return (
+    <nav className={`flex items-center justify-center gap-1 ${className}`}>
+      {/* Previous Button */}
+      <button
+        onClick={() => currentPage > 1 && handlePageChange(currentPage - 1)}
+        disabled={currentPage <= 1}
+        className={`flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+          currentPage <= 1
+            ? 'text-gray-600 cursor-not-allowed'
+            : 'text-gray-300 hover:bg-slate-700 hover:text-white'
+        }`}
+      >
+        <ChevronLeft className="w-4 h-4" />
+        <span className="hidden sm:inline">Previous</span>
+      </button>
+
+      {/* Page Numbers */}
+      <div className="flex items-center gap-1">
+        {pageNumbers.map((page, index) =>
+          page === 'ellipsis' ? (
+            <span
+              key={`ellipsis-${index}`}
+              className="px-2 py-2 text-gray-500 hidden md:block"
+            >
+              ...
+            </span>
+          ) : (
+            <button
+              key={page}
+              onClick={() => handlePageChange(page)}
+              className={`min-w-[40px] px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                currentPage === page
+                  ? 'bg-cyan-500 text-white'
+                  : 'text-gray-300 hover:bg-slate-700 hover:text-white'
+              }`}
+            >
+              {page}
+            </button>
+          )
+        )}
+      </div>
+
+      {/* Next Button */}
+      <button
+        onClick={() =>
+          currentPage < pageCount && handlePageChange(currentPage + 1)
+        }
+        disabled={currentPage >= pageCount}
+        className={`flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+          currentPage >= pageCount
+            ? 'text-gray-600 cursor-not-allowed'
+            : 'text-gray-300 hover:bg-slate-700 hover:text-white'
+        }`}
+      >
+        <span className="hidden sm:inline">Next</span>
+        <ChevronRight className="w-4 h-4" />
+      </button>
+    </nav>
+  )
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/search.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/search.tsx
@@ -1,0 +1,35 @@
+import { useRouter, useSearch } from "@tanstack/react-router";
+import { useDebouncedCallback } from "use-debounce";
+
+interface SearchProps {
+  readonly className?: string;
+}
+
+export function Search({ className = "" }: SearchProps) {
+  const search = useSearch({ strict: false });
+  const router = useRouter();
+
+  const handleSearch = useDebouncedCallback((term: string) => {
+    router.navigate({
+      to: ".",
+      search: (prev) => ({
+        ...prev,
+        page: 1,
+        query: term || undefined,
+      }),
+      replace: true,
+    });
+  }, 300);
+
+  return (
+    <input
+      type="text"
+      placeholder="Search articles..."
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        handleSearch(e.target.value)
+      }
+      defaultValue={(search as any)?.query || ""}
+      className={`w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 transition-colors ${className}`}
+    />
+  );
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/strapi-image.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/components/strapi-image.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { getStrapiMedia } from "@/lib/strapi-utils";
+
+interface StrapiImageProps {
+  src: string | undefined | null;
+  alt?: string | null;
+  className?: string;
+  width?: number | string;
+  height?: number | string;
+}
+
+export function StrapiImage({
+  src,
+  alt,
+  className = "",
+  width,
+  height,
+}: StrapiImageProps) {
+  const [hasError, setHasError] = useState(false);
+
+  if (!src) return null;
+
+  const imageUrl = getStrapiMedia(src);
+
+  if (hasError) {
+    return (
+      <div
+        className={`bg-slate-700 flex items-center justify-center text-slate-400 text-sm ${className}`}
+        style={{ width, height }}
+      >
+        <span>Image not available</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={imageUrl}
+      alt={alt || ""}
+      width={width}
+      height={height}
+      loading="lazy"
+      className={`object-cover ${className}`}
+      onError={() => setHasError(true)}
+    />
+  );
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/data/loaders/articles.ts
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/data/loaders/articles.ts
@@ -1,0 +1,106 @@
+import { createServerFn } from "@tanstack/react-start";
+import { sdk } from "@/data/strapi-sdk";
+import type { TArticle, TStrapiResponseCollection, TStrapiResponseSingle } from "@/types/strapi";
+
+const PAGE_SIZE = 3;
+
+const articles = sdk.collection("articles");
+
+/**
+ * Fetch articles with optional filtering, search, and pagination
+ */
+const getArticles = async (
+  page?: number,
+  category?: string,
+  query?: string
+) => {
+  const filterConditions: Array<Record<string, unknown>> = [];
+
+  // Add search query filter
+  if (query) {
+    filterConditions.push({
+      $or: [
+        { title: { $containsi: query } },
+        { description: { $containsi: query } },
+      ],
+    });
+  }
+
+  // Add category filter
+  if (category) {
+    filterConditions.push({
+      category: {
+        slug: { $eq: category },
+      },
+    });
+  }
+
+  const filters =
+    filterConditions.length === 0
+      ? undefined
+      : filterConditions.length === 1
+        ? filterConditions[0]
+        : { $and: filterConditions };
+
+  return articles.find({
+    sort: ["createdAt:desc"],
+    pagination: {
+      page: page || 1,
+      pageSize: PAGE_SIZE,
+    },
+    populate: ["cover", "author", "category"],
+    filters,
+  }) as Promise<TStrapiResponseCollection<TArticle>>;
+};
+
+/**
+ * Fetch a single article by documentId
+ */
+const getArticleById = async (documentId: string) => {
+  return articles.findOne(documentId, {
+    populate: ["cover", "author", "category", "blocks.file", "blocks.files"],
+  }) as Promise<TStrapiResponseSingle<TArticle>>;
+};
+
+/**
+ * Fetch a single article by slug
+ */
+const getArticleBySlug = async (slug: string) => {
+  return articles.find({
+    filters: {
+      slug: { $eq: slug },
+    },
+    populate: ["cover", "author", "category", "blocks.file", "blocks.files"],
+  }) as Promise<TStrapiResponseCollection<TArticle>>;
+};
+
+// Server Functions - these run on the server and can be called from components
+
+export const getArticlesData = createServerFn({
+  method: "GET",
+})
+  .inputValidator(
+    (input?: { page?: number; category?: string; query?: string }) => input
+  )
+  .handler(async ({ data }): Promise<TStrapiResponseCollection<TArticle>> => {
+    const response = await getArticles(data?.page, data?.category, data?.query);
+    return response;
+  });
+
+export const getArticleByIdData = createServerFn({
+  method: "GET",
+})
+  .inputValidator((documentId: string) => documentId)
+  .handler(async ({ data: documentId }): Promise<TStrapiResponseSingle<TArticle>> => {
+    const response = await getArticleById(documentId);
+    return response;
+  });
+
+export const getArticleBySlugData = createServerFn({
+  method: "GET",
+})
+  .inputValidator((slug: string) => slug)
+  .handler(async ({ data: slug }): Promise<TStrapiResponseCollection<TArticle>> => {
+    const response = await getArticleBySlug(slug);
+    return response;
+  });

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/data/loaders/index.ts
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/data/loaders/index.ts
@@ -1,0 +1,28 @@
+import {
+  getArticlesData,
+  getArticleByIdData,
+  getArticleBySlugData,
+} from "./articles";
+
+/**
+ * Strapi API - Server functions for fetching data from Strapi
+ *
+ * Usage in route loaders:
+ * ```ts
+ * import { strapiApi } from "@/data/loaders";
+ *
+ * export const Route = createFileRoute("/articles")({
+ *   loader: async () => {
+ *     const { data, meta } = await strapiApi.articles.getArticlesData();
+ *     return data;
+ *   },
+ * });
+ * ```
+ */
+export const strapiApi = {
+  articles: {
+    getArticlesData,
+    getArticleByIdData,
+    getArticleBySlugData,
+  },
+};

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/data/strapi-sdk.ts
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/data/strapi-sdk.ts
@@ -1,0 +1,9 @@
+import { strapi } from "@strapi/client";
+
+// Strapi base URL (without /api)
+const STRAPI_BASE = import.meta.env.VITE_STRAPI_URL ?? "http://localhost:1337";
+
+// Initialize the Strapi SDK with /api endpoint
+const sdk = strapi({ baseURL: new URL("/api", STRAPI_BASE).href });
+
+export { sdk };

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/lib/strapi-utils.ts
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/lib/strapi-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Strapi URL helpers
+ */
+
+const DEFAULT_STRAPI_URL = "http://localhost:1337";
+
+// Base Strapi URL (without /api)
+export function getStrapiURL(): string {
+  // Handle SSR where import.meta.env might not be fully available
+  if (typeof import.meta !== "undefined" && import.meta.env?.VITE_STRAPI_URL) {
+    return import.meta.env.VITE_STRAPI_URL;
+  }
+  return DEFAULT_STRAPI_URL;
+}
+
+// Get full URL for media assets
+export function getStrapiMedia(url: string | undefined | null): string {
+  if (!url) return "";
+  if (url.startsWith("data:") || url.startsWith("http") || url.startsWith("//")) {
+    return url;
+  }
+  // Ensure we always have a valid base URL
+  const baseUrl = getStrapiURL() || DEFAULT_STRAPI_URL;
+  return `${baseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+}

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/lib/strapiClient.ts
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/lib/strapiClient.ts
@@ -1,7 +1,0 @@
-import { strapi } from "@strapi/client";
-
-export const strapiClient = strapi({
-  baseURL: import.meta.env.VITE_STRAPI_URL,
-});
-
-export const articles = strapiClient.collection("articles");

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi.$articleId.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi.$articleId.tsx
@@ -4,7 +4,7 @@ import { StrapiImage } from "@/components/strapi-image";
 import { BlockRenderer } from "@/components/blocks";
 import type { TArticle } from "@/types/strapi";
 
-export const Route = createFileRoute("/demo/strapi_/$articleId")({
+export const Route = createFileRoute("/demo/strapi/$articleId")({
   component: RouteComponent,
   errorComponent: ErrorComponent,
   loader: async ({ params }) => {

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi.tsx
@@ -1,64 +1,290 @@
-import { articles } from '#/lib/strapiClient'
 import { createFileRoute, Link } from '@tanstack/react-router'
+import { z } from 'zod'
+import { strapiApi } from '@/data/loaders'
+import { StrapiImage } from '@/components/strapi-image'
+import { Search } from '@/components/search'
+import { Pagination } from '@/components/pagination'
+import type { TArticle } from '@/types/strapi'
+
+type LoaderResult = {
+  status: 'success' | 'empty' | 'error'
+  articles: TArticle[]
+  meta?: { pagination?: { page: number; pageCount: number; total: number } }
+  error?: string
+  query?: string
+}
+
+const searchSchema = z.object({
+  query: z.string().optional(),
+  page: z.number().default(1),
+})
 
 export const Route = createFileRoute('/demo/strapi')({
   component: RouteComponent,
-  loader: async () => {
-    const { data: strapiArticles } = await articles.find()
-    return strapiArticles
+  validateSearch: searchSchema,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ deps }): Promise<LoaderResult> => {
+    const { query, page } = deps.search
+    try {
+      const response = await strapiApi.articles.getArticlesData({
+        data: { query, page },
+      })
+
+      // Check if we got data
+      if (!response || !response.data) {
+        return {
+          status: 'empty',
+          articles: [],
+          meta: response?.meta,
+          query,
+        }
+      }
+
+      // Check if data array is empty
+      if (response.data.length === 0) {
+        return {
+          status: 'empty',
+          articles: [],
+          meta: response.meta,
+          query,
+        }
+      }
+
+      return {
+        status: 'success',
+        articles: response.data,
+        meta: response.meta,
+        query,
+      }
+    } catch (error) {
+      console.error('Strapi fetch error:', error)
+      return {
+        status: 'error',
+        articles: [],
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to connect to Strapi',
+        query,
+      }
+    }
   },
 })
 
+function StrapiServerInstructions() {
+  return (
+    <div className="bg-slate-800/50 rounded-lg p-6 text-left mt-6">
+      <h2 className="text-lg font-semibold text-white mb-4">
+        Start the Strapi Server
+      </h2>
+      <div className="space-y-2 text-sm font-mono text-gray-400">
+        <p>
+          <span className="text-cyan-400">$</span> cd ../server
+        </p>
+        <p>
+          <span className="text-cyan-400">$</span> npm install
+        </p>
+        <p>
+          <span className="text-cyan-400">$</span> npm run develop
+        </p>
+      </div>
+      <p className="text-gray-500 text-sm mt-4">
+        Then create an admin at{' '}
+        <a
+          href="http://localhost:1337/admin"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-cyan-400 hover:underline"
+        >
+          http://localhost:1337/admin
+        </a>
+      </p>
+    </div>
+  )
+}
+
+function ConnectionError({ error }: { error?: string }) {
+  return (
+    <div className="bg-amber-900/20 border border-amber-500/50 rounded-xl p-8">
+      <div className="flex items-start gap-4">
+        <div className="text-amber-400 text-2xl">⚠️</div>
+        <div>
+          <h2 className="text-xl font-semibold text-amber-400 mb-2">
+            Cannot Connect to Strapi
+          </h2>
+          <p className="text-gray-300 mb-4">
+            Make sure your Strapi server is running at{' '}
+            <code className="text-cyan-400 bg-slate-800 px-2 py-1 rounded">
+              http://localhost:1337
+            </code>
+          </p>
+          {error && (
+            <p className="text-gray-500 text-sm mb-4">Error: {error}</p>
+          )}
+          <StrapiServerInstructions />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function NoArticlesFound({ query }: { query?: string }) {
+  if (query) {
+    return (
+      <div className="bg-slate-800/50 border border-slate-700 rounded-xl p-8">
+        <div className="text-center">
+          <div className="text-6xl mb-4">🔍</div>
+          <h2 className="text-2xl font-semibold text-white mb-4">
+            No Results Found
+          </h2>
+          <p className="text-gray-400 mb-6 max-w-md mx-auto">
+            No articles match your search for "{query}". Try adjusting your
+            search terms.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-slate-800/50 border border-slate-700 rounded-xl p-8">
+      <div className="text-center">
+        <div className="text-6xl mb-4">📝</div>
+        <h2 className="text-2xl font-semibold text-white mb-4">
+          No Articles Yet
+        </h2>
+        <p className="text-gray-400 mb-6 max-w-md mx-auto">
+          Your Strapi server is running, but there are no published articles.
+          Create and publish your first article to see it here.
+        </p>
+
+        <div className="bg-slate-900/50 rounded-lg p-6 text-left max-w-md mx-auto">
+          <h3 className="text-lg font-semibold text-white mb-4">
+            How to add articles:
+          </h3>
+          <ol className="space-y-3 text-gray-400">
+            <li className="flex gap-3">
+              <span className="text-cyan-400 font-bold">1.</span>
+              <span>
+                Open{' '}
+                <a
+                  href="http://localhost:1337/admin"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-cyan-400 hover:underline"
+                >
+                  Strapi Admin Panel
+                </a>
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-cyan-400 font-bold">2.</span>
+              <span>
+                Go to <strong className="text-white">Content Manager</strong> →{' '}
+                <strong className="text-white">Article</strong>
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-cyan-400 font-bold">3.</span>
+              <span>
+                Click <strong className="text-white">Create new entry</strong>
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-cyan-400 font-bold">4.</span>
+              <span>
+                Fill in the details and click{' '}
+                <strong className="text-white">Publish</strong>
+              </span>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function RouteComponent() {
-  const strapiArticles = Route.useLoaderData()
+  const { status, articles, meta, error, query } = Route.useLoaderData()
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-slate-900 p-8">
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-4xl font-bold mb-8 text-white">
+        <h1 className="text-4xl font-bold mb-6 text-white">
           <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-transparent">
             Strapi
           </span>{' '}
           <span className="text-gray-300">Articles</span>
         </h1>
 
-        {strapiArticles && strapiArticles.length > 0 ? (
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {strapiArticles.map((article) => (
-              <Link
-                key={article.id}
-                to="/demo/strapi/$articleId"
-                params={{ articleId: article.documentId }}
-                className="block"
-              >
-                <article className="bg-slate-800/50 backdrop-blur-sm border border-slate-700 rounded-xl p-6 hover:border-cyan-500/50 transition-all duration-300 hover:shadow-lg hover:shadow-cyan-500/10 cursor-pointer h-full">
-                  <h2 className="text-xl font-semibold text-white mb-3">
-                    {article.title || 'Untitled'}
-                  </h2>
+        <div className="mb-8">
+          <Search />
+        </div>
 
-                  {article.description && (
-                    <p className="text-gray-400 mb-4 leading-relaxed">
-                      {article.description}
-                    </p>
-                  )}
+        {status === 'error' && <ConnectionError error={error} />}
 
-                  {article.content && (
-                    <p className="text-gray-400 line-clamp-3 leading-relaxed">
-                      {article.content}
-                    </p>
-                  )}
+        {status === 'empty' && <NoArticlesFound query={query} />}
 
-                  {article.createdAt && (
-                    <p className="text-sm text-cyan-400/70 mt-4">
-                      {new Date(article.createdAt).toLocaleDateString()}
-                    </p>
-                  )}
-                </article>
-              </Link>
-            ))}
-          </div>
-        ) : (
-          <p className="text-gray-400">No articles found.</p>
+        {status === 'success' && (
+          <>
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {articles.map((article: TArticle) => (
+                <Link
+                  key={article.id}
+                  to="/demo/strapi/$articleId"
+                  params={{ articleId: article.documentId }}
+                  className="block"
+                >
+                  <article className="bg-slate-800/50 backdrop-blur-sm border border-slate-700 rounded-xl overflow-hidden hover:border-cyan-500/50 transition-all duration-300 hover:shadow-lg hover:shadow-cyan-500/10 cursor-pointer h-full flex flex-col">
+                    <StrapiImage
+                      src={article.cover?.url}
+                      alt={article.cover?.alternativeText || article.title}
+                      className="w-full h-48"
+                    />
+
+                    <div className="p-6 flex flex-col flex-1">
+                      <h2 className="text-xl font-semibold text-white mb-3">
+                        {article.title || 'Untitled'}
+                      </h2>
+
+                      {article.description && (
+                        <p className="text-gray-400 mb-4 leading-relaxed line-clamp-2">
+                          {article.description}
+                        </p>
+                      )}
+
+                      <div className="mt-auto flex items-center justify-between">
+                        {article.author?.name && (
+                          <span className="text-sm text-gray-500">
+                            By {article.author.name}
+                          </span>
+                        )}
+                        {article.createdAt && (
+                          <span className="text-sm text-cyan-400/70">
+                            {new Date(article.createdAt).toLocaleDateString()}
+                          </span>
+                        )}
+                      </div>
+
+                      {article.category?.name && (
+                        <div className="mt-3">
+                          <span className="text-xs px-2 py-1 bg-slate-700 text-cyan-400 rounded-full">
+                            {article.category.name}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </article>
+                </Link>
+              ))}
+            </div>
+
+            {meta?.pagination && meta.pagination.pageCount > 1 && (
+              <div className="mt-8">
+                <Pagination pageCount={meta.pagination.pageCount} />
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi_.$articleId.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi_.$articleId.tsx
@@ -1,16 +1,95 @@
-import { articles } from '#/lib/strapiClient'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { strapiApi } from "@/data/loaders";
+import { StrapiImage } from "@/components/strapi-image";
+import { BlockRenderer } from "@/components/blocks";
+import type { TArticle } from "@/types/strapi";
 
-export const Route = createFileRoute('/demo/strapi_/$articleId')({
+export const Route = createFileRoute("/demo/strapi_/$articleId")({
   component: RouteComponent,
+  errorComponent: ErrorComponent,
   loader: async ({ params }) => {
-    const { data: article } = await articles.findOne(params.articleId)
-    return article
+    try {
+      const response = await strapiApi.articles.getArticleByIdData({
+        data: params.articleId,
+      });
+      return { success: true, article: response.data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to load article",
+        article: null,
+      };
+    }
   },
-})
+});
+
+function ErrorComponent({ error }: { error: Error }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-slate-900 p-8">
+      <div className="max-w-4xl mx-auto">
+        <Link
+          to="/demo/strapi"
+          className="inline-flex items-center text-cyan-400 hover:text-cyan-300 mb-6 transition-colors"
+        >
+          ← Back to Articles
+        </Link>
+        <div className="bg-red-900/20 border border-red-500/50 rounded-xl p-8 text-center">
+          <h1 className="text-2xl font-bold text-red-400 mb-4">Error Loading Article</h1>
+          <p className="text-gray-300">{error.message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function RouteComponent() {
-  const article = Route.useLoaderData()
+  const { success, article, error } = Route.useLoaderData() as {
+    success: boolean;
+    article: TArticle | null;
+    error?: string;
+  };
+
+  // Show error state
+  if (!success || !article) {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-slate-900 p-8">
+        <div className="max-w-4xl mx-auto">
+          <Link
+            to="/demo/strapi"
+            className="inline-flex items-center text-cyan-400 hover:text-cyan-300 mb-6 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 mr-2"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+            Back to Articles
+          </Link>
+
+          <div className="bg-amber-900/20 border border-amber-500/50 rounded-xl p-8">
+            <div className="flex items-start gap-4">
+              <div className="text-amber-400 text-2xl">⚠️</div>
+              <div>
+                <h2 className="text-xl font-semibold text-amber-400 mb-2">
+                  {error || "Article Not Found"}
+                </h2>
+                <p className="text-gray-300">
+                  Make sure the Strapi server is running and the article exists.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-slate-900 p-8">
@@ -34,45 +113,58 @@ function RouteComponent() {
           Back to Articles
         </Link>
 
-        <article className="bg-slate-800/50 backdrop-blur-sm border border-slate-700 rounded-xl p-8">
-          <h1 className="text-4xl font-bold text-white mb-4">
-            {article?.title || 'Untitled'}
-          </h1>
+        <article className="bg-slate-800/50 backdrop-blur-sm border border-slate-700 rounded-xl overflow-hidden">
+          <StrapiImage
+            src={article.cover?.url}
+            alt={article.cover?.alternativeText || article.title}
+            className="w-full h-64"
+          />
 
-          {article?.createdAt && (
-            <p className="text-sm text-cyan-400/70 mb-6">
-              Published on{' '}
-              {new Date(article?.createdAt).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-            </p>
-          )}
+          <div className="p-8">
+            <h1 className="text-4xl font-bold text-white mb-4">
+              {article.title || "Untitled"}
+            </h1>
 
-          {article?.description && (
-            <div className="mb-6">
-              <h2 className="text-xl font-semibold text-gray-300 mb-3">
-                Description
-              </h2>
-              <p className="text-gray-400 leading-relaxed">
-                {article?.description}
-              </p>
+            <div className="flex items-center gap-4 mb-6">
+              {article.author?.name && (
+                <span className="text-gray-400">
+                  By{" "}
+                  <span className="text-cyan-400">{article.author.name}</span>
+                </span>
+              )}
+              {article.createdAt && (
+                <span className="text-sm text-cyan-400/70">
+                  {new Date(article.createdAt).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </span>
+              )}
             </div>
-          )}
 
-          {article?.content && (
-            <div>
-              <h2 className="text-xl font-semibold text-gray-300 mb-3">
-                Content
-              </h2>
-              <div className="text-gray-400 leading-relaxed whitespace-pre-wrap">
-                {article?.content}
+            {article.category?.name && (
+              <div className="mb-6">
+                <span className="text-xs px-3 py-1 bg-slate-700 text-cyan-400 rounded-full">
+                  {article.category.name}
+                </span>
               </div>
-            </div>
-          )}
+            )}
+
+            {article.description && (
+              <div className="mb-8">
+                <p className="text-xl text-gray-300 leading-relaxed">
+                  {article.description}
+                </p>
+              </div>
+            )}
+
+            {article.blocks && article.blocks.length > 0 && (
+              <BlockRenderer blocks={article.blocks} />
+            )}
+          </div>
         </article>
       </div>
     </div>
-  )
+  );
 }

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/types/strapi.ts
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/types/strapi.ts
@@ -1,0 +1,90 @@
+/**
+ * Strapi type definitions
+ * These types match the Strapi Cloud Template Blog schema
+ */
+
+import type { Block } from "@/components/blocks";
+
+// Base image type from Strapi media library
+export type TImage = {
+  id: number;
+  documentId: string;
+  alternativeText: string | null;
+  url: string;
+};
+
+// Author content type
+export type TAuthor = {
+  id: number;
+  documentId: string;
+  name: string;
+  email?: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+};
+
+// Category content type
+export type TCategory = {
+  id: number;
+  documentId: string;
+  name: string;
+  slug: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+};
+
+// Article content type
+export type TArticle = {
+  id: number;
+  documentId: string;
+  title: string;
+  description: string;
+  slug: string;
+  cover?: TImage;
+  author?: TAuthor;
+  category?: TCategory;
+  blocks?: Array<Block>;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+};
+
+// Strapi response wrappers
+export type TStrapiResponseSingle<T> = {
+  data: T;
+  meta?: {
+    pagination?: TStrapiPagination;
+  };
+};
+
+export type TStrapiResponseCollection<T> = {
+  data: Array<T>;
+  meta?: {
+    pagination?: TStrapiPagination;
+  };
+};
+
+export type TStrapiPagination = {
+  page: number;
+  pageSize: number;
+  pageCount: number;
+  total: number;
+};
+
+export type TStrapiError = {
+  status: number;
+  name: string;
+  message: string;
+  details?: Record<string, Array<string>>;
+};
+
+export type TStrapiResponse<T = null> = {
+  data?: T;
+  error?: TStrapiError;
+  meta?: {
+    pagination?: TStrapiPagination;
+  };
+};

--- a/packages/create/src/frameworks/react/add-ons/strapi/info.json
+++ b/packages/create/src/frameworks/react/add-ons/strapi/info.json
@@ -8,14 +8,6 @@
   "color": "#4945FF",
   "priority": 110,
   "modes": ["file-router"],
-  "dependsOn": ["start"],
-  "command": {
-    "command": "sh",
-    "args": [
-      "-c",
-      "cd .. && git clone --depth 1 https://github.com/strapi/strapi-cloud-template-blog.git server && cd server && rm -rf .git .yarnrc.yml yarn.lock && cp .env.example .env"
-    ]
-  },
   "routes": [
     {
       "url": "/demo/strapi",

--- a/packages/create/src/frameworks/react/add-ons/strapi/info.json
+++ b/packages/create/src/frameworks/react/add-ons/strapi/info.json
@@ -8,12 +8,20 @@
   "color": "#4945FF",
   "priority": 110,
   "modes": ["file-router"],
+  "dependsOn": ["start"],
+  "command": {
+    "command": "sh",
+    "args": [
+      "-c",
+      "cd .. && git clone --depth 1 https://github.com/strapi/strapi-cloud-template-blog.git server && cd server && rm -rf .git .yarnrc.yml yarn.lock && cp .env.example .env"
+    ]
+  },
   "routes": [
     {
       "url": "/demo/strapi",
-      "name": "Strapi",
-      "path": "src/routes/demo.strapi.tsx",
-      "jsName": "StrapiDemo"
+      "name": "Strapi Articles",
+      "path": "src/routes/demo/strapi.tsx",
+      "jsName": "StrapiArticles"
     }
   ]
 }

--- a/packages/create/src/frameworks/react/add-ons/strapi/package.json
+++ b/packages/create/src/frameworks/react/add-ons/strapi/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
-    "@strapi/client": "^1.5.0"
+    "@strapi/client": "^1.6.0",
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.0",
+    "use-debounce": "^10.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds Strapi CMS integration add-on for TanStack Start, creating a sibling directory structure with a TanStack frontend and Strapi backend.

## Features

- Article listing with search and pagination
- Article detail pages with dynamic block rendering
- Block types: rich-text, quotes, media, image sliders
- Markdown content rendering with GitHub Flavored Markdown
- URL-based search and pagination (shareable/bookmarkable)
- Graceful error handling with helpful setup instructions
- Uses official `@strapi/client` SDK with TanStack Start server functions

## Video Overview

https://github.com/user-attachments/assets/375bca8f-25d5-43d4-a096-3096c049a479


## Test Plan

### 1. Create the app

```bash
node packages/cli/dist/bin.js create my-app --add-ons strapi
```

### 2. Start the Strapi server

```bash
cd server
npm install
npm run develop
```

### 3. Set up Strapi admin

1. Open http://localhost:1337/admin
2. Create an admin account
3. Go to **Content Manager > Article**
4. Create a new article with title, description, cover image, and content blocks
5. **IMPORTANT: Click "Publish" button** - articles must be published to appear in the API

### 4. Start the TanStack app

```bash
cd my-app
npm install
npm run dev
```

### 5. Verify features

- [ ] Visit http://localhost:3000/demo/strapi - articles list displays
- [ ] Search filters results in real-time
- [ ] Pagination navigates between pages
- [ ] Click article to view detail page
- [ ] All blocks render correctly (rich-text, quote, media, slider)
- [ ] Images load with fallback on error
- [ ] URL params persist (`?query=test&page=2`)

### Error states to verify

- [ ] Stop Strapi server → shows "Cannot Connect" with setup instructions
- [ ] Delete all articles → shows "No Articles Yet" with creation guide
- [ ] Search for non-existent term → shows "No Results Found"

## Files Added

```
packages/create/src/frameworks/react/add-ons/strapi/
├── info.json
├── package.json
├── README.md
└── assets/src/
    ├── components/
    │   ├── blocks/ (block-renderer, rich-text, quote, media, slider)
    │   ├── markdown-content.tsx
    │   ├── pagination.tsx
    │   ├── search.tsx
    │   └── strapi-image.tsx
    ├── data/
    │   ├── strapi-sdk.ts
    │   └── loaders/articles.ts
    ├── lib/strapi-utils.ts
    ├── routes/demo/
    │   ├── strapi.tsx
    │   └── strapi_.$articleId.tsx
    └── types/strapi.ts
```

## Dependencies Added

| Package | Purpose |
|---------|---------|
| `@strapi/client` | Official Strapi SDK |
| `react-markdown` | Markdown rendering |
| `remark-gfm` | GitHub Flavored Markdown |
| `use-debounce` | Debounced search input |

---