### PR TITLE
Use `node:url` in default vite.config.ts

### DIFF
--- a/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
+++ b/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
@@ -6,7 +6,7 @@ import { paraglideVitePlugin } from "@inlang/paraglide-js"
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react'
 import viteTsConfigPaths from 'vite-tsconfig-paths'
-import { fileURLToPath, URL } from 'url'
+import { fileURLToPath, URL } from 'node:url'
 import tailwindcss from "@tailwindcss/vite"
 <% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportContent(integration) %>
 <% } %>


### PR DESCRIPTION
By default, Deno does not allow importing bare node modules outside of `node_modules/` directories. This replaces the import from `url` with an import from `node:url` to make it easier for Deno users to use the Tanstack Start template.