### PR TITLE
Fix: Change link to correctly point to CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx @tanstack/cli create --list-add-ons
 
 ## Documentation
 
-- [CLI Reference](https://tanstack.com/start/latest/docs/framework/react/quick-start)
+- [CLI Reference](https://tanstack.com/cli/latest/docs/cli-reference)
 - [TanStack Start](https://tanstack.com/start)
 - [TanStack Router](https://tanstack.com/router)
 


### PR DESCRIPTION
This PR addresses the `README.md` file at the repository's root. It contains the link: CLI Reference, which points to the wrong set of docs: Start Quickstart. 

### Changes

Change the link: CLI Reference, to instead point to the [CLI Reference](https://tanstack.com/cli/latest/docs/cli-reference) in the CLI docs. 