### PR TITLE
fix: stabilize scaffolds for Neon, Solid, and path aliases

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/ai-devtools.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/ai-devtools.tsx
@@ -1,3 +1,0 @@
-import { aiDevtoolsPlugin } from '@tanstack/react-ai-devtools'
-
-export default aiDevtoolsPlugin()

--- a/packages/create/src/frameworks/react/add-ons/ai/info.json
+++ b/packages/create/src/frameworks/react/add-ons/ai/info.json
@@ -36,11 +36,6 @@
       "type": "header-user",
       "path": "src/components/demo-AIAssistant.tsx",
       "jsName": "TanChatAIAssistant"
-    },
-    {
-      "type": "devtools",
-      "path": "src/lib/ai-devtools.tsx",
-      "jsName": "AiDevtools"
     }
   ],
   "dependsOn": ["store"],

--- a/packages/create/src/frameworks/react/add-ons/ai/package.json
+++ b/packages/create/src/frameworks/react/add-ons/ai/package.json
@@ -7,7 +7,6 @@
     "@tanstack/ai-ollama": "latest",
     "@tanstack/ai-openai": "latest",
     "@tanstack/ai-react": "latest",
-    "@tanstack/react-ai-devtools": "latest",
     "highlight.js": "^11.11.1",
     "streamdown": "^1.6.5",
     "lucide-react": "^0.544.0",

--- a/packages/create/src/frameworks/react/add-ons/neon/assets/_dot_env.example.append
+++ b/packages/create/src/frameworks/react/add-ons/neon/assets/_dot_env.example.append
@@ -1,4 +1,4 @@
 # These will be automatically created by Neon Launchpad (https://neon.new).
 # You will also need to 
-VITE_DATABASE_URL=
-VITE_DATABASE_URL_POOLER=
+DATABASE_URL=
+DATABASE_URL_POOLER=

--- a/packages/create/src/frameworks/react/add-ons/neon/assets/neon-vite-plugin.ts
+++ b/packages/create/src/frameworks/react/add-ons/neon/assets/neon-vite-plugin.ts
@@ -6,5 +6,5 @@ export default postgresPlugin({
     path: 'db/init.sql',
   },
   referrer: 'create-tanstack',
-  dotEnvKey: 'VITE_DATABASE_URL',
+  dotEnvKey: 'DATABASE_URL',
 })

--- a/packages/create/src/frameworks/react/add-ons/neon/assets/src/db.ts
+++ b/packages/create/src/frameworks/react/add-ons/neon/assets/src/db.ts
@@ -3,11 +3,11 @@ import { neon } from '@neondatabase/serverless'
 let client: ReturnType<typeof neon>
 
 export async function getClient() {
-  if (!process.env.VITE_DATABASE_URL) {
+  if (!process.env.DATABASE_URL) {
     return undefined
   }
   if (!client) {
-    client = await neon(process.env.VITE_DATABASE_URL!)
+    client = await neon(process.env.DATABASE_URL!)
   }
   return client
 }

--- a/packages/create/src/frameworks/react/project/base/package.json
+++ b/packages/create/src/frameworks/react/project/base/package.json
@@ -17,7 +17,7 @@
     "lucide-react": "^0.561.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "vite-tsconfig-paths": "^6.0.2"
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
     "@tanstack/devtools-vite": "^0.3.11",

--- a/packages/create/src/frameworks/solid/add-ons/solid-ui/info.json
+++ b/packages/create/src/frameworks/solid/add-ons/solid-ui/info.json
@@ -6,9 +6,5 @@
   "modes": ["file-router", "code-router"],
   "type": "add-on",
   "category": "styling",
-  "color": "#000000",
-  "command": {
-    "command": "npx",
-    "args": ["solidui-cli@latest", "add", "button", "input"]
-  }
+  "color": "#000000"
 }


### PR DESCRIPTION
## Summary
- switch Neon scaffolded DB env usage from `VITE_DATABASE_URL` to server-only `DATABASE_URL` in template env files, runtime DB client usage, and Neon Vite plugin wiring
- pin React base template `vite-tsconfig-paths` to `^5.1.4` to match known-working behavior and avoid the current `^6` alias resolution breakage reports
- remove blocking post-create `solidui-cli` command execution and remove AI devtools scaffold integration dependency/path to avoid startup/runtime failures in generated projects

## Notes
- This targets the first stability/security batch: #287, #273, #315, #316
- Issue #319 was already closed separately as fixed by #330