### PR TITLE
fix: restore tRPC provider wiring in React scaffolds

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/info.json
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/info.json
@@ -19,7 +19,7 @@
   ],
   "integrations": [
     {
-      "type": "root-provider",
+      "type": "provider",
       "path": "src/integrations/tanstack-query/root-provider.tsx",
       "jsName": "TanStackQueryProvider"
     },


### PR DESCRIPTION
## Summary
- change the React TanStack Query integration type from `root-provider` to `provider`
- ensure generated root route wraps the app with `TanStackQueryProvider`, which also supplies the `TRPCProvider` when tRPC is enabled

## Why
- with `root-provider`, the provider integration was never injected into `__root.tsx`, so `useTRPC()` ran outside `TRPCProvider`
- this addresses the scaffold/runtime failure reported in #271 (and duplicate #275)