### PR TITLE
fix: stop strict Sentry pin and externalize Sentry in Nitro

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/sentry/package.json
+++ b/packages/create/src/frameworks/react/add-ons/sentry/package.json
@@ -5,7 +5,7 @@
     "start": "node --import ./.output/server/instrument.server.mjs .output/server/index.mjs"
   },
   "dependencies": {
-    "@sentry/tanstackstart-react": "10.34.0",
+    "@sentry/tanstackstart-react": "^10.34.0",
     "dotenv-cli": "^11.0.0"
   }
 }

--- a/packages/create/src/frameworks/react/hosts/nitro/info.json
+++ b/packages/create/src/frameworks/react/hosts/nitro/info.json
@@ -13,7 +13,7 @@
     {
       "type": "vite-plugin",
       "import": "import { nitro } from 'nitro/vite'",
-      "code": "nitro()"
+      "code": "nitro({ rollupConfig: { external: [/^@sentry\\//] } })"
     }
   ],
   "default": true

--- a/packages/create/src/frameworks/react/hosts/railway/info.json
+++ b/packages/create/src/frameworks/react/hosts/railway/info.json
@@ -13,7 +13,7 @@
     {
       "type": "vite-plugin",
       "import": "import { nitro } from 'nitro/vite'",
-      "code": "nitro()"
+      "code": "nitro({ rollupConfig: { external: [/^@sentry\\//] } })"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace strict `@sentry/tanstackstart-react` pin (`10.34.0`) with `^10.34.0`
- update Nitro and Railway deployment integrations to externalize `@sentry/*` during Nitro rollup

## Why
- upstream Sentry thread for TanStack Start build failures with `10.35+` points to externalizing `@sentry/*` as the current workaround
- this lets us avoid hard pinning while keeping generated Nitro-based builds stable

## Reference
- getsentry/sentry-javascript#19142 (comment 3872692410)