### PR TITLE
fix: treat bare --add-ons as interactive selection

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -280,7 +280,7 @@ export function cli({
       )!.id
 
       let finalOptions: Options | undefined
-      if (cliOptions.interactive) {
+      if (cliOptions.interactive || cliOptions.addOns === true) {
         cliOptions.addOns = true
       } else {
         finalOptions = await normalizeOptions(


### PR DESCRIPTION
## Summary
- update create command flow to treat `--add-ons` without explicit values as interactive add-on selection mode
- keep existing non-interactive behavior when explicit add-on IDs are provided

## Why
- users running `pnpm create @tanstack/start@latest . --add-ons` expected the add-on picker to appear
- previously this path was handled as non-interactive normalization, so no picker was shown

Fixes #234