### PR TITLE
fix: improve exported add-on compatibility and better-auth handlers

### DIFF
--- a/packages/cli/src/command-line.ts
+++ b/packages/cli/src/command-line.ts
@@ -136,6 +136,9 @@ export async function normalizeOptions(
       ])
       if (cliOptions.addOns && Array.isArray(cliOptions.addOns)) {
         for (const a of cliOptions.addOns) {
+          if (a.toLowerCase() === 'start') {
+            continue
+          }
           selectedAddOns.add(a)
         }
       }

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -118,6 +118,9 @@ export async function promptForCreateOptions(
 
   if (Array.isArray(cliOptions.addOns)) {
     for (const addOn of cliOptions.addOns) {
+      if (addOn.toLowerCase() === 'start') {
+        continue
+      }
       addOns.add(addOn)
     }
   } else {

--- a/packages/cli/tests/command-line.test.ts
+++ b/packages/cli/tests/command-line.test.ts
@@ -218,6 +218,35 @@ describe('normalizeOptions', () => {
     expect(options?.typescript).toBe(true)
   })
 
+  it('should ignore legacy start add-on id from exported commands', async () => {
+    __testRegisterFramework({
+      id: 'react-cra',
+      name: 'react',
+      getAddOns: () => [
+        {
+          id: 'tanstack-query',
+          name: 'TanStack Query',
+          modes: ['file-router'],
+        },
+        {
+          id: 'nitro',
+          name: 'nitro',
+          modes: ['file-router'],
+          default: true,
+        },
+      ],
+    })
+
+    const options = await normalizeOptions({
+      projectName: 'test',
+      addOns: ['start', 'tanstack-query'],
+      framework: 'react-cra',
+    })
+
+    expect(options?.chosenAddOns.map((a) => a.id)).toContain('tanstack-query')
+    expect(options?.chosenAddOns.map((a) => a.id)).not.toContain('start')
+  })
+
   it('should handle toolchain as an addon', async () => {
     __testRegisterFramework({
       id: 'react-cra',

--- a/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx
+++ b/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx
@@ -23,7 +23,9 @@ export default function BetterAuthHeader() {
           </div>
         )}
         <button
-          onClick={() => authClient.signOut()}
+          onClick={() => {
+            void authClient.signOut()
+          }}
           className="flex-1 h-9 px-4 text-sm font-medium bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-50 border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
         >
           Sign out

--- a/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/routes/demo/better-auth.tsx
+++ b/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/routes/demo/better-auth.tsx
@@ -57,7 +57,9 @@ function BetterAuthDemo() {
           </div>
 
           <button
-            onClick={() => authClient.signOut()}
+            onClick={() => {
+              void authClient.signOut()
+            }}
             className="w-full h-9 px-4 text-sm font-medium border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
           >
             Sign out

--- a/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx
+++ b/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx
@@ -38,7 +38,9 @@ export default function BetterAuthHeader() {
               {(image) => <img src={image()} alt="" class="h-8 w-8" />}
             </Show>
             <button
-              onClick={() => authClient.signOut()}
+              onClick={() => {
+                void authClient.signOut();
+              }}
               class="flex-1 h-9 px-4 text-sm font-medium bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-50 border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
             >
               Sign out

--- a/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/routes/demo.better-auth.tsx
+++ b/packages/create/src/frameworks/solid/add-ons/better-auth/assets/src/routes/demo.better-auth.tsx
@@ -210,7 +210,9 @@ function BetterAuthDemo() {
               </div>
 
               <button
-                onClick={() => authClient.signOut()}
+                onClick={() => {
+                  void authClient.signOut();
+                }}
                 class="w-full h-9 px-4 text-sm font-medium border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
               >
                 Sign out


### PR DESCRIPTION
## Summary
- ignore legacy `start` add-on IDs when provided by exported CLI command strings
- preserve selected valid add-ons in the same command (e.g. `form,shadcn,table,start,tanstack-query`)
- make better-auth sign-out click handlers explicitly fire-and-forget to satisfy stricter lint/toolchain rules

## Why
- some exported builder commands still include `start`, which is not a valid add-on id in current CLI flows and causes create to fail
- better-auth sign-out handlers can trip strict lint rules in generated apps when promise-returning handlers are not explicitly handled

Fixes #299
Fixes #301