### PR TITLE
fix: scaffold missing src/router entry files

### DIFF
--- a/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
@@ -1,0 +1,27 @@
+import { createRouter as createTanStackRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+<% if (addOnEnabled['tanstack-query']) { %>
+import { getContext } from './integrations/tanstack-query/root-provider'
+<% } %>
+
+export function getRouter() {
+  const router = createTanStackRouter({
+    routeTree,
+<% if (addOnEnabled['tanstack-query']) { %>
+    context: getContext(),
+<% } else if (addOnEnabled['apollo-client']) { %>
+    context: {} as any,
+<% } %>
+    scrollRestoration: true,
+    defaultPreload: 'intent',
+    defaultPreloadStaleTime: 0,
+  })
+
+  return router
+}
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: ReturnType<typeof getRouter>
+  }
+}

--- a/packages/create/src/frameworks/solid/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/router.tsx.ejs
@@ -1,0 +1,25 @@
+import { createRouter as createTanStackRouter } from '@tanstack/solid-router'
+import { routeTree } from './routeTree.gen'
+<% if (addOnEnabled['tanstack-query']) { %>
+import { getContext } from './integrations/tanstack-query/provider'
+<% } %>
+
+export function getRouter() {
+  const router = createTanStackRouter({
+    routeTree,
+<% if (addOnEnabled['tanstack-query']) { %>
+    context: getContext(),
+<% } %>
+    scrollRestoration: true,
+    defaultPreload: 'intent',
+    defaultPreloadStaleTime: 0,
+  })
+
+  return router
+}
+
+declare module '@tanstack/solid-router' {
+  interface Register {
+    router: ReturnType<typeof getRouter>
+  }
+}


### PR DESCRIPTION
## Summary
- add `src/router.tsx` templates to both React and Solid base project scaffolds
- export `getRouter` from each scaffolded router entry and register router types
- wire tanstack-query context into generated router config when that add-on is enabled

## Why
- newer Start plugin-core now requires a resolvable `src/router` entry
- generated projects without this file fail at dev startup with `Could not resolve entry for router entry: router`

Fixes #360