### PR TITLE
fix: make eslint toolchain format script run checks

### DIFF
--- a/packages/create/src/frameworks/react/toolchains/eslint/package.json
+++ b/packages/create/src/frameworks/react/toolchains/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "lint": "eslint",
-    "format": "prettier",
+    "format": "prettier --check .",
     "check": "prettier --write . && eslint --fix"
   },
   "devDependencies": {

--- a/packages/create/src/frameworks/solid/toolchains/eslint/package.json
+++ b/packages/create/src/frameworks/solid/toolchains/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "lint": "eslint",
-    "format": "prettier",
+    "format": "prettier --check .",
     "check": "prettier --write . && eslint --fix"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- update React and Solid eslint toolchain `format` scripts from bare `prettier` to `prettier --check .`
- keep `check` script behavior as full write+fix

## Why
- bare `prettier` only prints help and does not format/check project files
- generated apps should have a working `format` script out of the box

Fixes #267