### PR TITLE
fix: file paths missing .js extension for ESM

### DIFF
--- a/packages/create/src/file-helpers.ts
+++ b/packages/create/src/file-helpers.ts
@@ -4,8 +4,8 @@ import { basename, extname, resolve } from 'node:path'
 import parseGitignore from 'parse-gitignore'
 import ignore from 'ignore'
 
-import { hasDrive, stripDrive } from './utils'
-import type { Environment } from './types'
+import { hasDrive, stripDrive } from './utils.js'
+import type { Environment } from './types.js'
 
 const BINARY_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico']
 
@@ -232,10 +232,10 @@ const PROJECT_FILES = ['package.json']
 export function createIgnore(path: string, includeProjectFiles = true) {
   const ignoreList = existsSync(resolve(path, '.gitignore'))
     ? (
-        parseGitignore(
-          readFileSync(resolve(path, '.gitignore')),
-        ) as unknown as { patterns: Array<string> }
-      ).patterns
+      parseGitignore(
+        readFileSync(resolve(path, '.gitignore')),
+      ) as unknown as { patterns: Array<string> }
+    ).patterns
     : []
   const ig = ignore().add(ignoreList)
   return (filePath: string) => {


### PR DESCRIPTION
Fixes https://github.com/TanStack/cli/issues/364

A couple of imports were added in https://github.com/TanStack/cli/commit/f4c9e904ec12f7c32275af03f455b690b5cf11b6 without a `.js` file extension. This does not get flagged by `pnpm build` because tsconfig isn't on a `module` that enforces ESM.

I can see other files in this repo using ESM-style imports, so this PR does that for these new ones, rather than updating tsconfig which could cause wider changes.