### PR TITLE
docs: fix OpenCode mcp config

### DIFF
--- a/docs/mcp/connecting.md
+++ b/docs/mcp/connecting.md
@@ -30,6 +30,23 @@ Restart Claude Desktop after editing.
 claude mcp add tanstack -- npx @tanstack/cli mcp
 ```
 
+## OpenCode
+
+Add to your [OpenCode JSON config file](https://opencode.ai/docs/config/):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "tanstack": {
+      "type": "local",
+      "command": ["npx", "@tanstack/cli", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
 ## Cursor
 
 Add to your Cursor MCP config:

--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -40,7 +40,7 @@ Add to your [OpenCode JSON config file](https://opencode.ai/docs/config/):
 	"$schema": "https://opencode.ai/config.json",
 	"mcp": {
       "tanstack": {
-        "type": "remote",
+        "type": "local",
         "command": ["npx", "@tanstack/cli", "mcp"],
         "enabled": true
       },


### PR DESCRIPTION
OpenCode requires "url" and doesn't accept "command" for `type:remote`, we can run mcp servers using npx command with `type:local`, OpenCode MCP Docs: https://opencode.ai/docs/mcp-servers