### PR TITLE
fix: tanstack query provider missing

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -1,10 +1,12 @@
 <% if (addOnEnabled.tRPC) { %>
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import superjson from "superjson";
 import { createTRPCClient, httpBatchStreamLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 
 import type { TRPCRouter } from "@/integrations/trpc/router";
+
+import { TRPCProvider } from "@/integrations/trpc/react";
 
 function getUrl() {
   const base = (() => {
@@ -40,6 +42,19 @@ export function getContext() {
     trpc: serverHelpers,
   };
 }
+
+export default function Provider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const queryClient = useQueryClient();
+  return (
+    <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+      {children}
+    </TRPCProvider>
+  );
+}
 <% } else { %>
 import { QueryClient } from '@tanstack/react-query'
 
@@ -48,5 +63,13 @@ export function getContext() {
   return {
     queryClient,
   };
+}
+
+export default function Provider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
 }
 <% } %>

--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/package.json
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@tanstack/react-query": "^5.66.5",
-    "@tanstack/react-query-devtools": "^5.84.2"
+    "@tanstack/react-query-devtools": "^5.84.2",
+    "@tanstack/react-router-ssr-query": "^1.159.10"
   }
 }

--- a/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
@@ -1,14 +1,19 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 <% if (addOnEnabled['tanstack-query']) { %>
+import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query'
 import { getContext } from './integrations/tanstack-query/root-provider'
 <% } %>
 
 export function getRouter() {
+<% if (addOnEnabled['tanstack-query']) { %>
+  const { queryClient, ...rest } = getContext()
+<% } %>
+
   const router = createTanStackRouter({
     routeTree,
 <% if (addOnEnabled['tanstack-query']) { %>
-    context: getContext(),
+    context: { queryClient, ...rest },
 <% } else if (addOnEnabled['apollo-client']) { %>
     context: {} as any,
 <% } %>
@@ -16,6 +21,13 @@ export function getRouter() {
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
   })
+
+<% if (addOnEnabled['tanstack-query']) { %>
+  setupRouterSsrQueryIntegration({
+    router,
+    queryClient,
+  })
+<% } %>
 
   return router
 }


### PR DESCRIPTION
# Summary
This should fix #372, the issue seems to be that QueryProvider was removed, I've manged to find some discussions related to the commit that removed the provider.
One comment linked to [these docs](https://tanstack.com/router/latest/docs/integrations/query) so I assumed the intent was to use the ssr query package in the router and tried using it in this PR. Sorry if that wasn't the original intent

# Changes
* Add `@tanstack/react-router-ssr-query` as a dependency for the query add-on
* Add some handling specific for tanstack query in the router
* Add the providers back from earlier commits

-----
I'm not very familiar with this code base and couldn't find a better way to do the following
* add the `@tanstack/react-router-ssr-query` to the router
* pull the query provider conditionally from the add-on (Added an empty provider for now)

Let me know if this is fine or there's a better way to do this, for now I've tested locally and made sure the add-ons work together and by themselves