### PR TITLE
Add 'baseLocale' to paraglideVitePlugin strategy

### DIFF
--- a/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
+++ b/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
@@ -20,7 +20,7 @@ const config = defineConfig({
   plugins: [devtools(), <% if (addOnEnabled.paraglide) { %>paraglideVitePlugin({
     project: './project.inlang',
     outdir: './src/paraglide',
-    strategy: ['url'],
+    strategy: ['url', "baseLocale"],
   }), <% } %><% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportCode(integration) %>,<% } %>
     // this is the plugin that enables path aliases
     viteTsConfigPaths({


### PR DESCRIPTION
Added the `baseLocale` configuration to the paraglide `strategy`. This ensures that paraglide has a fallback locale configured, preventing the "no locale found" error during routing and rendering.

<img width="1190" height="229" alt="Screenshot 2026-02-16 at 12 03 31" src="https://github.com/user-attachments/assets/21273032-f5ce-4b94-9b05-36340c04b8a3" />

