### PR TITLE
fix(create): use type-only import for Convex Id in React demo template

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/convex/assets/src/routes/demo/convex.tsx
+++ b/packages/create/src/frameworks/react/add-ons/convex/assets/src/routes/demo/convex.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation } from 'convex/react'
 import { Trash2, Plus, Check, Circle } from 'lucide-react'
 
 import { api } from '../../../convex/_generated/api'
-import { Id } from '../../../convex/_generated/dataModel'
+import type { Id } from '../../../convex/_generated/dataModel'
 
 export const Route = createFileRoute('/demo/convex')({
   ssr: false,


### PR DESCRIPTION
## Summary
- Changes React Convex demo template to import `Id` as type-only.
- Aligns React template with Solid Convex template behavior.
- Prevents module resolution/build issues where `dataModel` is type-only (`.d.ts`).

## Change
In:
`packages/create/src/frameworks/react/add-ons/convex/assets/src/routes/demo/convex.tsx`

From:
```ts
import { Id } from '../../../convex/_generated/dataModel'
```

To:
```ts
import type { Id } from '../../../convex/_generated/dataModel'
```

## Why
`Id` is only used as a type and should not be emitted as runtime import.

## Test plan
- [ ] Generate app with Convex add-on using create flow
- [ ] Run `npx convex dev`
- [ ] Run `npm run dev` / `npm run build`
- [ ] Confirm no resolution error for `convex/_generated/dataModel`

Fixes issue #377 