### PR TITLE
fix: Export TanStackQueryProvider as default for Query Client addon

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -41,12 +41,21 @@ export function getContext() {
   };
 }
 <% } else { %>
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 export function getContext() {
   const queryClient = new QueryClient();
   return {
     queryClient,
   };
+}
+
+export default function TanStackQueryProvider({ children }: { children: React.ReactNode }) {
+  const { queryClient } = getContext()
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  )
 }
 <% } %>


### PR DESCRIPTION
Previously, in issue #372, the Query Client addon file only exported getContext(), which returned a `QueryClient ` instance.

This change adds and exports `TanStackQueryProvider `as the default export, wrapping the app with `QueryClientProvider ` using the queryClient from `getContext()`. It can also close the PR #373 

**This ensures:**
- Consumers can directly use the provider as the default export
- The Query addon works correctly without requiring manual provider setup
- No changes to query configuration logic — only the provider export structure was updated