### PR TITLE
feat(create): migrate React templates to package import aliases

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
@@ -5,8 +5,8 @@ import { Store } from '@tanstack/store'
 import { Send, X, ChevronRight, BotIcon } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 
-import { useGuitarRecommendationChat } from '@/lib/demo-ai-hook'
-import type { ChatMessages } from '@/lib/demo-ai-hook'
+import { useGuitarRecommendationChat } from '#/lib/demo-ai-hook'
+import type { ChatMessages } from '#/lib/demo-ai-hook'
 
 import GuitarRecommendation from './demo-GuitarRecommendation'
 

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-GuitarRecommendation.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-GuitarRecommendation.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from '@tanstack/react-router'
 
 import { showAIAssistant } from './demo-AIAssistant'
 
-import guitars from '@/data/demo-guitars'
+import guitars from '#/data/demo-guitars'
 
 export default function GuitarRecommendation({ id }: { id: string }) {
   const navigate = useNavigate()

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/demo-ai-hook.ts
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/demo-ai-hook.ts
@@ -6,7 +6,7 @@ import {
 import type { InferChatMessages } from '@tanstack/ai-react'
 import { clientTools } from '@tanstack/ai-client'
 
-import { recommendGuitarToolDef } from '@/lib/demo-guitar-tools'
+import { recommendGuitarToolDef } from '#/lib/demo-guitar-tools'
 
 const recommendGuitarToolClient = recommendGuitarToolDef.client(({ id }) => ({
   id: +id,

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/demo-guitar-tools.ts
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/demo-guitar-tools.ts
@@ -1,6 +1,6 @@
 import { toolDefinition } from '@tanstack/ai'
 import { z } from 'zod'
-import guitars from '@/data/demo-guitars'
+import guitars from '#/data/demo-guitars'
 
 // Tool definition for getting guitars
 export const getGuitarsToolDef = toolDefinition({

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/ai-chat.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/ai-chat.tsx
@@ -11,12 +11,12 @@ import {
 } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 
-import { useGuitarRecommendationChat } from '@/lib/demo-ai-hook'
-import type { ChatMessages } from '@/lib/demo-ai-hook'
-import { useAudioRecorder } from '@/hooks/demo-useAudioRecorder'
-import { useTTS } from '@/hooks/demo-useTTS'
+import { useGuitarRecommendationChat } from '#/lib/demo-ai-hook'
+import type { ChatMessages } from '#/lib/demo-ai-hook'
+import { useAudioRecorder } from '#/hooks/demo-useAudioRecorder'
+import { useTTS } from '#/hooks/demo-useTTS'
 
-import GuitarRecommendation from '@/components/demo-GuitarRecommendation'
+import GuitarRecommendation from '#/components/demo-GuitarRecommendation'
 
 import './ai-chat.css'
 

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/api.ai.chat.ts
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/api.ai.chat.ts
@@ -5,7 +5,7 @@ import { openaiText } from '@tanstack/ai-openai'
 import { geminiText } from '@tanstack/ai-gemini'
 import { ollamaText } from '@tanstack/ai-ollama'
 
-import { getGuitars, recommendGuitarToolDef } from '@/lib/demo-guitar-tools'
+import { getGuitars, recommendGuitarToolDef } from '#/lib/demo-guitar-tools'
 
 const SYSTEM_PROMPT = `You are a helpful assistant for a store that sells guitars.
 

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/guitars/$guitarId.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/guitars/$guitarId.tsx
@@ -1,6 +1,6 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
 
-import guitars from '@/data/demo-guitars'
+import guitars from '#/data/demo-guitars'
 
 export const Route = createFileRoute('/demo/guitars/$guitarId')({
   component: RouteComponent,

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/guitars/index.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/routes/demo/guitars/index.tsx
@@ -1,6 +1,6 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
 
-import guitars from '@/data/demo-guitars'
+import guitars from '#/data/demo-guitars'
 
 export const Route = createFileRoute('/demo/guitars/')({
   component: GuitarsIndex,

--- a/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx
+++ b/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/integrations/better-auth/header-user.tsx
@@ -1,4 +1,4 @@
-import { authClient } from "@/lib/auth-client";
+import { authClient } from "#/lib/auth-client";
 import { Link } from "@tanstack/react-router";
 
 export default function BetterAuthHeader() {

--- a/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/routes/api/auth/$.ts
+++ b/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/routes/api/auth/$.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { auth } from '@/lib/auth'
+import { auth } from '#/lib/auth'
 
 export const Route = createFileRoute('/api/auth/$')({
   server: {

--- a/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/routes/demo/better-auth.tsx
+++ b/packages/create/src/frameworks/react/add-ons/better-auth/assets/src/routes/demo/better-auth.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
-import { authClient } from "@/lib/auth-client";
+import { authClient } from "#/lib/auth-client";
 
 export const Route = createFileRoute("/demo/better-auth")({
   component: BetterAuthDemo,

--- a/packages/create/src/frameworks/react/add-ons/db/assets/src/components/demo.chat-area.tsx
+++ b/packages/create/src/frameworks/react/add-ons/db/assets/src/components/demo.chat-area.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { useChat, useMessages } from '@/hooks/demo.useChat'
+import { useChat, useMessages } from '#/hooks/demo.useChat'
 
 import Messages from './demo.messages'
 

--- a/packages/create/src/frameworks/react/add-ons/db/assets/src/components/demo.messages.tsx
+++ b/packages/create/src/frameworks/react/add-ons/db/assets/src/components/demo.messages.tsx
@@ -1,4 +1,4 @@
-import type { Message } from '@/db-collections'
+import type { Message } from '#/db-collections'
 
 export const getAvatarColor = (username: string) => {
   const colors = [

--- a/packages/create/src/frameworks/react/add-ons/db/assets/src/hooks/demo.useChat.ts
+++ b/packages/create/src/frameworks/react/add-ons/db/assets/src/hooks/demo.useChat.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useLiveQuery } from '@tanstack/react-db'
 
-import { messagesCollection, type Message } from '@/db-collections'
+import { messagesCollection, type Message } from '#/db-collections'
 
 import type { Collection } from '@tanstack/react-db'
 

--- a/packages/create/src/frameworks/react/add-ons/db/assets/src/routes/demo/db-chat.tsx
+++ b/packages/create/src/frameworks/react/add-ons/db/assets/src/routes/demo/db-chat.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import ChatArea from '@/components/demo.chat-area'
+import ChatArea from '#/components/demo.chat-area'
 
 export const Route = createFileRoute('/demo/db-chat')({
   component: App,

--- a/packages/create/src/frameworks/react/add-ons/drizzle/assets/src/routes/demo/drizzle.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/drizzle/assets/src/routes/demo/drizzle.tsx.ejs
@@ -1,8 +1,8 @@
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
-import { db } from '@/db/index'
+import { db } from '#/db/index'
 import { desc } from 'drizzle-orm'
-import { todos } from '@/db/schema'
+import { todos } from '#/db/schema'
 
 const getTodos = createServerFn({
   method: 'GET',

--- a/packages/create/src/frameworks/react/add-ons/form/assets/src/components/demo.FormComponents.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/form/assets/src/components/demo.FormComponents.tsx.ejs
@@ -1,14 +1,14 @@
 import { useStore } from '@tanstack/react-form'
 
-import { useFieldContext, useFormContext } from '@/hooks/demo.form-context'
+import { useFieldContext, useFormContext } from '#/hooks/demo.form-context'
 <% if (addOnEnabled.shadcn) { %>
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Textarea as ShadcnTextarea } from '@/components/ui/textarea'
-import * as ShadcnSelect from '@/components/ui/select'
-import { Slider as ShadcnSlider } from '@/components/ui/slider'
-import { Switch as ShadcnSwitch } from '@/components/ui/switch'
-import { Label } from '@/components/ui/label'
+import { Button } from '#/components/ui/button'
+import { Input } from '#/components/ui/input'
+import { Textarea as ShadcnTextarea } from '#/components/ui/textarea'
+import * as ShadcnSelect from '#/components/ui/select'
+import { Slider as ShadcnSlider } from '#/components/ui/slider'
+import { Switch as ShadcnSwitch } from '#/components/ui/switch'
+import { Label } from '#/components/ui/label'
 
 export function SubscribeButton({ label }: { label: string }) {
   const form = useFormContext()

--- a/packages/create/src/frameworks/react/add-ons/form/assets/src/routes/demo/form.address.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/form/assets/src/routes/demo/form.address.tsx.ejs
@@ -1,6 +1,6 @@
 import { <% if (fileRouter) { %>createFileRoute<% } else { %>createRoute<% } %> } from '@tanstack/react-router'
 
-import { useAppForm } from '@/hooks/demo.form'
+import { useAppForm } from '#/hooks/demo.form'
 
 <% if (codeRouter) { %>
 import type { RootRoute } from '@tanstack/react-router'

--- a/packages/create/src/frameworks/react/add-ons/form/assets/src/routes/demo/form.simple.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/form/assets/src/routes/demo/form.simple.tsx.ejs
@@ -1,7 +1,7 @@
 import { <% if (fileRouter) { %>createFileRoute<% } else { %>createRoute<% } %> } from '@tanstack/react-router'
 import { z } from 'zod'
 
-import { useAppForm } from '@/hooks/demo.form'
+import { useAppForm } from '#/hooks/demo.form'
 
 <% if (codeRouter) { %>
   import type { RootRoute } from '@tanstack/react-router'

--- a/packages/create/src/frameworks/react/add-ons/mcp/assets/src/routes/demo/api.mcp-todos.ts
+++ b/packages/create/src/frameworks/react/add-ons/mcp/assets/src/routes/demo/api.mcp-todos.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { addTodo, getTodos, subscribeToTodos } from '@/mcp-todos'
+import { addTodo, getTodos, subscribeToTodos } from '#/mcp-todos'
 
 export const Route = createFileRoute('/api/mcp-todos')({
   server: {

--- a/packages/create/src/frameworks/react/add-ons/mcp/assets/src/routes/mcp.ts
+++ b/packages/create/src/frameworks/react/add-ons/mcp/assets/src/routes/mcp.ts
@@ -2,9 +2,9 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { createFileRoute } from '@tanstack/react-router'
 import z from 'zod'
 
-import { handleMcpRequest } from '@/utils/mcp-handler'
+import { handleMcpRequest } from '#/utils/mcp-handler'
 
-import { addTodo } from '@/mcp-todos'
+import { addTodo } from '#/mcp-todos'
 
 const server = new McpServer({
   name: 'start-server',

--- a/packages/create/src/frameworks/react/add-ons/neon/assets/src/routes/demo/neon.tsx
+++ b/packages/create/src/frameworks/react/add-ons/neon/assets/src/routes/demo/neon.tsx
@@ -1,7 +1,7 @@
 import { createServerFn } from '@tanstack/react-start'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 
-import { getClient } from '@/db'
+import { getClient } from '#/db'
 
 const getTodos = createServerFn({
   method: 'GET',

--- a/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/orpc/client.ts
+++ b/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/orpc/client.ts
@@ -7,7 +7,7 @@ import { createIsomorphicFn } from '@tanstack/react-start'
 
 import type { RouterClient } from '@orpc/server'
 
-import router from '@/orpc/router'
+import router from '#/orpc/router'
 
 const getORPCClient = createIsomorphicFn()
   .server(() =>

--- a/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/routes/api.$.ts
+++ b/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/routes/api.$.ts
@@ -1,4 +1,4 @@
-import '@/polyfill'
+import '#/polyfill'
 
 import { OpenAPIHandler } from '@orpc/openapi/fetch'
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4'
@@ -7,8 +7,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { onError } from '@orpc/server'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
 
-import { TodoSchema } from '@/orpc/schema'
-import router from '@/orpc/router'
+import { TodoSchema } from '#/orpc/schema'
+import router from '#/orpc/router'
 
 const handler = new OpenAPIHandler(router, {
   interceptors: [

--- a/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/routes/api.rpc.$.ts
+++ b/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/routes/api.rpc.$.ts
@@ -1,8 +1,8 @@
-import '@/polyfill'
+import '#/polyfill'
 
 import { RPCHandler } from '@orpc/server/fetch'
 import { createFileRoute } from '@tanstack/react-router'
-import router from '@/orpc/router'
+import router from '#/orpc/router'
 
 const handler = new RPCHandler(router)
 

--- a/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/routes/demo/orpc-todo.tsx
+++ b/packages/create/src/frameworks/react/add-ons/oRPC/assets/src/routes/demo/orpc-todo.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
-import { orpc } from '@/orpc/client'
+import { orpc } from '#/orpc/client'
 
 export const Route = createFileRoute('/demo/orpc-todo')({
   component: ORPCTodos,

--- a/packages/create/src/frameworks/react/add-ons/paraglide/assets/src/components/LocaleSwitcher.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/paraglide/assets/src/components/LocaleSwitcher.tsx.ejs
@@ -1,8 +1,8 @@
 // Locale switcher refs:
 // - Paraglide docs: https://inlang.com/m/gerre34r/library-inlang-paraglideJs
 // - Router example: https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide#switching-locale
-import { getLocale, locales, setLocale } from '@/paraglide/runtime'
-import { m } from '@/paraglide/messages'
+import { getLocale, locales, setLocale } from '#/paraglide/runtime'
+import { m } from '#/paraglide/messages'
 
 export default function ParaglideLocaleSwitcher() {
   const currentLocale = getLocale()

--- a/packages/create/src/frameworks/react/add-ons/paraglide/assets/src/routes/demo.i18n.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/paraglide/assets/src/routes/demo.i18n.tsx.ejs
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import logo from "../logo.svg";
-import { m } from "@/paraglide/messages";
+import { m } from "#/paraglide/messages";
 import LocaleSwitcher from "../components/LocaleSwitcher";
 
 export const Route = createFileRoute("/demo/i18n")({

--- a/packages/create/src/frameworks/react/add-ons/prisma/assets/src/routes/demo/prisma.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/prisma/assets/src/routes/demo/prisma.tsx.ejs
@@ -1,6 +1,6 @@
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
-import { prisma } from '@/db'
+import { prisma } from '#/db'
 
 const getTodos = createServerFn({
   method: 'GET',

--- a/packages/create/src/frameworks/react/add-ons/shadcn/assets/components.json
+++ b/packages/create/src/frameworks/react/add-ons/shadcn/assets/components.json
@@ -11,11 +11,11 @@
     "prefix": ""
   },
   "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib",
-    "hooks": "@/hooks"
+    "components": "#/components",
+    "utils": "#/lib/utils",
+    "ui": "#/components/ui",
+    "lib": "#/lib",
+    "hooks": "#/hooks"
   },
   "iconLibrary": "lucide"
 }

--- a/packages/create/src/frameworks/react/add-ons/store/assets/src/routes/demo/store.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/store/assets/src/routes/demo/store.tsx.ejs
@@ -1,7 +1,7 @@
 import { <% if (fileRouter) { %>createFileRoute<% } else { %>createRoute<% } %> } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 
-import { fullName, store } from '@/lib/demo-store'
+import { fullName, store } from '#/lib/demo-store'
 <% if (codeRouter) { %>
 import type { RootRoute } from '@tanstack/react-router'
 <% } else { %>

--- a/packages/create/src/frameworks/react/add-ons/storybook/assets/src/routes/demo/storybook.tsx
+++ b/packages/create/src/frameworks/react/add-ons/storybook/assets/src/routes/demo/storybook.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 
-import { Dialog } from "@/components/storybook/dialog";
-import { Input } from "@/components/storybook/input";
-import { RadioGroup } from "@/components/storybook/radio-group";
-import { Slider } from "@/components/storybook/slider";
-import { Button } from "@/components/storybook/button";
+import { Dialog } from "#/components/storybook/dialog";
+import { Input } from "#/components/storybook/input";
+import { RadioGroup } from "#/components/storybook/radio-group";
+import { Slider } from "#/components/storybook/slider";
+import { Button } from "#/components/storybook/button";
 
 export const Route = createFileRoute("/demo/storybook")({
   component: StorybookDemo,

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi.tsx
@@ -1,4 +1,4 @@
-import { articles } from '@/lib/strapiClient'
+import { articles } from '#/lib/strapiClient'
 import { createFileRoute, Link } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/demo/strapi')({

--- a/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi_.$articleId.tsx
+++ b/packages/create/src/frameworks/react/add-ons/strapi/assets/src/routes/demo/strapi_.$articleId.tsx
@@ -1,4 +1,4 @@
-import { articles } from '@/lib/strapiClient'
+import { articles } from '#/lib/strapiClient'
 import { createFileRoute, Link } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/demo/strapi_/$articleId')({

--- a/packages/create/src/frameworks/react/add-ons/t3env/README.md
+++ b/packages/create/src/frameworks/react/add-ons/t3env/README.md
@@ -7,7 +7,7 @@
 ### Usage
 
 ```ts
-import { env } from "@/env";
+import { env } from "#/env";
 
 console.log(env.VITE_APP_TITLE);
 ```

--- a/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/integrations/trpc/react.ts
+++ b/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/integrations/trpc/react.ts
@@ -1,4 +1,4 @@
 import { createTRPCContext } from "@trpc/tanstack-react-query";
-import type { TRPCRouter } from "@/integrations/trpc/router";
+import type { TRPCRouter } from "#/integrations/trpc/router";
 
 export const { TRPCProvider, useTRPC } = createTRPCContext<TRPCRouter>();

--- a/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/routes/api.trpc.$.tsx
+++ b/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/routes/api.trpc.$.tsx
@@ -1,6 +1,6 @@
 import { createServerFileRoute } from '@tanstack/react-start/server'
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
-import { trpcRouter } from '@/integrations/trpc/router'
+import { trpcRouter } from '#/integrations/trpc/router'
 import { createFileRoute } from '@tanstack/react-router'
 
 function handler({ request }: { request: Request }) {

--- a/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/routes/demo/trpc-todo.tsx
+++ b/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/routes/demo/trpc-todo.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { useTRPC } from '@/integrations/trpc/react'
+import { useTRPC } from '#/integrations/trpc/react'
 
 export const Route = createFileRoute('/demo/trpc-todo')({
   component: TRPCTodos,

--- a/packages/create/src/frameworks/react/add-ons/table/assets/src/routes/demo/table.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/table/assets/src/routes/demo/table.tsx.ejs
@@ -11,7 +11,7 @@ import {
 } from '@tanstack/react-table'
 import { compareItems, rankItem } from '@tanstack/match-sorter-utils'
 
-import { makeData } from '@/data/demo-table-data'
+import { makeData } from '#/data/demo-table-data'
 
 import type {
   Column,
@@ -24,7 +24,7 @@ import type { RankingInfo } from '@tanstack/match-sorter-utils'
 <% if (codeRouter) { %>
 import type { RootRoute } from '@tanstack/react-router'
 <% } %>
-import type { Person } from '@/data/demo-table-data'
+import type { Person } from '#/data/demo-table-data'
 <% if (fileRouter) { %>
 export const Route = createFileRoute('/demo/table')({
   component: TableDemo,

--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -5,8 +5,8 @@ import superjson from "superjson";
 import { createTRPCClient, httpBatchStreamLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 
-import type { TRPCRouter } from "@/integrations/trpc/router";
-import { TRPCProvider } from '@/integrations/trpc/react'
+import type { TRPCRouter } from "#/integrations/trpc/router";
+import { TRPCProvider } from '#/integrations/trpc/react'
 
 function getUrl() {
   const base = (() => {

--- a/packages/create/src/frameworks/react/examples/events/assets/src/components/RemyAssistant.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/components/RemyAssistant.tsx
@@ -3,8 +3,8 @@ import { Send, X, ChefHat, Croissant } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 import { Store } from '@tanstack/store'
 
-import { useConferenceChat } from '@/lib/conference-ai-hook'
-import type { ConferenceChatMessages } from '@/lib/conference-ai-hook'
+import { useConferenceChat } from '#/lib/conference-ai-hook'
+import type { ConferenceChatMessages } from '#/lib/conference-ai-hook'
 
 function Messages({ messages }: { messages: ConferenceChatMessages }) {
   const messagesContainerRef = useRef<HTMLDivElement>(null)

--- a/packages/create/src/frameworks/react/examples/events/assets/src/components/SpeakerCard.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/components/SpeakerCard.tsx
@@ -3,7 +3,7 @@ import { MapPin } from 'lucide-react'
 
 import { type Speaker } from 'content-collections'
 
-import { Card, CardContent } from '@/components/ui/card'
+import { Card, CardContent } from '#/components/ui/card'
 
 interface SpeakerCardProps {
   speaker: Speaker

--- a/packages/create/src/frameworks/react/examples/events/assets/src/components/TalkCard.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/components/TalkCard.tsx
@@ -3,7 +3,7 @@ import { Clock, User } from 'lucide-react'
 
 import { type Talk } from 'content-collections'
 
-import { Card, CardContent } from '@/components/ui/card'
+import { Card, CardContent } from '#/components/ui/card'
 
 interface TalkCardProps {
   talk: Talk

--- a/packages/create/src/frameworks/react/examples/events/assets/src/components/ui/card.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { cn } from '@/lib/utils'
+import { cn } from '#/lib/utils'
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (

--- a/packages/create/src/frameworks/react/examples/events/assets/src/routes/api.remy-chat.ts
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/routes/api.remy-chat.ts
@@ -11,7 +11,7 @@ import {
   getAllSpeakers,
   getAllTalks,
   searchConference,
-} from '@/lib/conference-tools'
+} from '#/lib/conference-tools'
 
 export const Route = createFileRoute('/api/remy-chat')({
   server: {

--- a/packages/create/src/frameworks/react/examples/events/assets/src/routes/index.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/routes/index.tsx
@@ -3,10 +3,10 @@ import { ArrowRight, Calendar, MapPin, Users } from 'lucide-react'
 
 import { allSpeakers, allTalks } from 'content-collections'
 
-import SpeakerCard from '@/components/SpeakerCard'
-import TalkCard from '@/components/TalkCard'
-import RemyAssistant from '@/components/RemyAssistant'
-import HeroCarousel from '@/components/HeroCarousel'
+import SpeakerCard from '#/components/SpeakerCard'
+import TalkCard from '#/components/TalkCard'
+import RemyAssistant from '#/components/RemyAssistant'
+import HeroCarousel from '#/components/HeroCarousel'
 
 export const Route = createFileRoute('/')({
   component: HomePage,

--- a/packages/create/src/frameworks/react/examples/events/assets/src/routes/schedule.index.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/routes/schedule.index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 
 import { allTalks, allSpeakers } from 'content-collections'
 
-import RemyAssistant from '@/components/RemyAssistant'
+import RemyAssistant from '#/components/RemyAssistant'
 
 export const Route = createFileRoute('/schedule/')({
   component: SchedulePage,

--- a/packages/create/src/frameworks/react/examples/events/assets/src/routes/speakers.$slug.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/routes/speakers.$slug.tsx
@@ -5,8 +5,8 @@ import { Link } from '@tanstack/react-router'
 
 import { allSpeakers, allTalks } from 'content-collections'
 
-import RemyAssistant from '@/components/RemyAssistant'
-import TalkCard from '@/components/TalkCard'
+import RemyAssistant from '#/components/RemyAssistant'
+import TalkCard from '#/components/TalkCard'
 
 export const Route = createFileRoute('/speakers/$slug')({
   loader: async ({ params }) => {

--- a/packages/create/src/frameworks/react/examples/events/assets/src/routes/speakers.index.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/routes/speakers.index.tsx
@@ -2,8 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { allSpeakers } from 'content-collections'
 
-import SpeakerCard from '@/components/SpeakerCard'
-import RemyAssistant from '@/components/RemyAssistant'
+import SpeakerCard from '#/components/SpeakerCard'
+import RemyAssistant from '#/components/RemyAssistant'
 
 export const Route = createFileRoute('/speakers/')({
   component: SpeakersPage,

--- a/packages/create/src/frameworks/react/examples/events/assets/src/routes/talks.$slug.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/routes/talks.$slug.tsx
@@ -4,7 +4,7 @@ import { Clock, User, ArrowLeft, Tag } from 'lucide-react'
 
 import { allTalks, allSpeakers } from 'content-collections'
 
-import RemyAssistant from '@/components/RemyAssistant'
+import RemyAssistant from '#/components/RemyAssistant'
 
 export const Route = createFileRoute('/talks/$slug')({
   loader: async ({ params }) => {

--- a/packages/create/src/frameworks/react/examples/events/assets/src/routes/talks.index.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/routes/talks.index.tsx
@@ -2,8 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { allTalks } from 'content-collections'
 
-import TalkCard from '@/components/TalkCard'
-import RemyAssistant from '@/components/RemyAssistant'
+import TalkCard from '#/components/TalkCard'
+import RemyAssistant from '#/components/RemyAssistant'
 
 export const Route = createFileRoute('/talks/')({
   component: TalksPage,

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/components/ResumeAssistant.tsx
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/components/ResumeAssistant.tsx
@@ -3,8 +3,8 @@ import { Send, X, Briefcase, UserCheck } from "lucide-react";
 import { Streamdown } from "streamdown";
 import { Store } from "@tanstack/store";
 
-import { useResumeChat } from "@/lib/resume-ai-hook";
-import type { ResumeChatMessages } from "@/lib/resume-ai-hook";
+import { useResumeChat } from "#/lib/resume-ai-hook";
+import type { ResumeChatMessages } from "#/lib/resume-ai-hook";
 
 function Messages({ messages }: { messages: ResumeChatMessages }) {
   const messagesContainerRef = useRef<HTMLDivElement>(null);

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/badge.tsx
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/badge.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "#/lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/card.tsx
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "#/lib/utils"
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/checkbox.tsx
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { CheckIcon } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "#/lib/utils"
 
 function Checkbox({
   className,

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/hover-card.tsx
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/hover-card.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
 
-import { cn } from "@/lib/utils"
+import { cn } from "#/lib/utils"
 
 function HoverCard({
   ...props

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/separator.tsx
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
-import { cn } from "@/lib/utils"
+import { cn } from "#/lib/utils"
 
 function Separator({
   className,

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/routes/api.resume-chat.ts
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/routes/api.resume-chat.ts
@@ -10,7 +10,7 @@ import {
   getAllJobs,
   getAllEducation,
   searchExperience,
-} from '@/lib/resume-tools'
+} from '#/lib/resume-tools'
 
 export const Route = createFileRoute('/api/resume-chat')({
   server: {

--- a/packages/create/src/frameworks/react/examples/resume/assets/src/routes/index.tsx
+++ b/packages/create/src/frameworks/react/examples/resume/assets/src/routes/index.tsx
@@ -3,17 +3,17 @@ import { marked } from 'marked'
 
 import { createFileRoute } from '@tanstack/react-router'
 import { allJobs, allEducations } from 'content-collections'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Checkbox } from '@/components/ui/checkbox'
-import { Badge } from '@/components/ui/badge'
-import { Separator } from '@/components/ui/separator'
+import { Card, CardContent, CardHeader, CardTitle } from '#/components/ui/card'
+import { Checkbox } from '#/components/ui/checkbox'
+import { Badge } from '#/components/ui/badge'
+import { Separator } from '#/components/ui/separator'
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-} from '@/components/ui/hover-card'
+} from '#/components/ui/hover-card'
 
-import ResumeAssistant from '@/components/ResumeAssistant'
+import ResumeAssistant from '#/components/ResumeAssistant'
 
 export const Route = createFileRoute('/')({
   component: App,

--- a/packages/create/src/frameworks/react/project/base/package.json
+++ b/packages/create/src/frameworks/react/project/base/package.json
@@ -2,6 +2,9 @@
   "name": "",
   "private": true,
   "type": "module",
+  "imports": {
+    "#/*": "./src/*"
+  },
   "scripts": {
     "dev": "vite dev --port 3000",
     "build": "vite build",
@@ -16,8 +19,7 @@
     "@tanstack/react-start": "^1.132.0",
     "lucide-react": "^0.561.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0",
-    "vite-tsconfig-paths": "^5.1.4"
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
     "@tanstack/devtools-vite": "^0.3.11",
@@ -29,6 +31,7 @@
     "jsdom": "^27.0.0",
     "typescript": "^5.7.2",
     "vite": "^7.1.7",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   }
 }

--- a/packages/create/src/frameworks/react/project/base/src/routes/__root.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/routes/__root.tsx.ejs
@@ -8,7 +8,7 @@ import Header from '../components/Header'
 <% } %><% for(const integration of integrations.filter(i => i.type === 'layout' || i.type === 'provider' || i.type === 'devtools')) { %>
 import <%= integration.jsName %> from '<%= relativePath(integration.path, true) %>'
 <% } %><% if (addOnEnabled.paraglide) { %>
-import { getLocale } from '@/paraglide/runtime'
+import { getLocale } from '#/paraglide/runtime'
 <% } %>
 import appCss from '../styles.css?url'
 <% if (addOnEnabled["apollo-client"]) { %>
@@ -17,7 +17,7 @@ import type { ApolloClientIntegration } from "@apollo/client-integration-tanstac
 <% if (addOnEnabled["tanstack-query"]) { %>
 import type { QueryClient } from '@tanstack/react-query'
 <% if (addOnEnabled.tRPC) { %>
-import type { TRPCRouter } from '@/integrations/trpc/router'
+import type { TRPCRouter } from '#/integrations/trpc/router'
 import type { TRPCOptionsProxy } from '@trpc/tanstack-react-query'
 <% } %>
 <% } %>

--- a/packages/create/src/frameworks/react/project/base/tsconfig.json.ejs
+++ b/packages/create/src/frameworks/react/project/base/tsconfig.json.ejs
@@ -5,6 +5,10 @@
     "target": "ES2022",
     "jsx": "react-jsx",
     "module": "ESNext",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["vite/client"],
 
@@ -21,10 +25,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noUncheckedSideEffectImports": true
   }
 }

--- a/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
+++ b/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
@@ -1,31 +1,22 @@
 import { defineConfig } from 'vite'
 import { devtools } from '@tanstack/devtools-vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
 <% if (addOnEnabled.paraglide) { -%>
 import { paraglideVitePlugin } from "@inlang/paraglide-js"
 <% } -%>
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react'
-import viteTsConfigPaths from 'vite-tsconfig-paths'
-import { fileURLToPath, URL } from 'node:url'
 import tailwindcss from "@tailwindcss/vite"
 <% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportContent(integration) %>
 <% } %>
 
 const config = defineConfig({
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
   plugins: [devtools(), <% if (addOnEnabled.paraglide) { %>paraglideVitePlugin({
     project: './project.inlang',
     outdir: './src/paraglide',
     strategy: ['url'],
   }), <% } %><% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportCode(integration) %>,<% } %>
-    // this is the plugin that enables path aliases
-    viteTsConfigPaths({
-      projects: ['./tsconfig.json'],
-    }),
+    tsconfigPaths({ projects: ['./tsconfig.json'] }),
     tailwindcss(),
     tanstackStart(),
     viteReact(<% if (addOnEnabled.compiler) { %>{


### PR DESCRIPTION
## Summary
- migrate React template imports from `@/` to package import aliases (`#/`) across base templates, add-ons, and examples
- add `"imports": { "#/*": "./src/*" }` to generated React app `package.json`
- keep compatibility for existing `@/` imports by retaining `tsconfig` path mapping and `vite-tsconfig-paths` in generated React apps

## Why
- moves template code toward package-import aliases while preserving compatibility with upstream scaffold files that still reference `@/`
- avoids breaking generated app builds during the transition

## Validation
- `pnpm --filter @tanstack/create test`
- full pre-commit workspace build/test hooks
- smoke scaffold + install + build using local CLI: `--add-ons ai,tRPC,tanstack-query`

Fixes #218

## Release note
- intentionally no changeset in this PR; batching release entries together as requested