### PR TITLE
fixed unnecessary string() call

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/t3env/assets/src/env.ts
+++ b/packages/create/src/frameworks/react/add-ons/t3env/assets/src/env.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
  
 export const env = createEnv({
   server: {
-    SERVER_URL: z.string().url().optional(),
+    SERVER_URL: z.url().optional(),
   },
  
   /**


### PR DESCRIPTION
Fixed unnecessary `string()` call because in zod v4 it's deprecated (solidjs version already has this change)