### PR TITLE
refactor(create): prisma & drizzle-kit to devDeps

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/drizzle/package.json.ejs
+++ b/packages/create/src/frameworks/react/add-ons/drizzle/package.json.ejs
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "drizzle-orm": "^0.45.1",
-    "drizzle-kit": "^0.31.9"<% if (addOnOption.drizzle.database === 'postgresql') { %>,
+    "drizzle-orm": "^0.45.1"<% if (addOnOption.drizzle.database === 'postgresql') { %>,
     "pg": "^8.16.3"<% } %><% if (addOnOption.drizzle.database === 'mysql') { %>,
     "mysql2": "^3.15.3"<% } %><% if (addOnOption.drizzle.database === 'sqlite') { %>,
     "better-sqlite3": "^12.6.2"<% } %>
   },
   "devDependencies": {
+    "drizzle-kit": "^0.31.9",
     "dotenv": "^17.3.1",
     "tsx": "^4.21.0"<% if (addOnOption.drizzle.database === 'postgresql') { %>,
     "@types/pg": "^8.15.6"<% } %><% if (addOnOption.drizzle.database === 'sqlite') { %>,

--- a/packages/create/src/frameworks/react/add-ons/prisma/package.json.ejs
+++ b/packages/create/src/frameworks/react/add-ons/prisma/package.json.ejs
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "prisma": "^7.4.2",
     "@prisma/client": "^7.4.2"<% if (addOnOption.prisma.database === 'postgres') { %>,
     "@prisma/adapter-pg": "^7.4.2"<% } %><% if (addOnOption.prisma.database === 'mysql') { %>,
     "@prisma/adapter-mariadb": "^7.4.2"<% } %><% if (addOnOption.prisma.database === 'sqlite') { %>,
     "@prisma/adapter-better-sqlite3": "^7.4.2"<% } %>
   },
   "devDependencies": {
+    "prisma": "^7.4.2",
     "dotenv-cli": "^11.0.0",
     "tsx": "^4.21.0"
   },


### PR DESCRIPTION
As per official documentation below, `prisma` and `drizzle-kit` should be installed as dev dependencies:
- www.prisma.io/docs/orm/prisma-client/setup-and-configuration/introduction#installation
- https://orm.drizzle.team/docs/kit-overview

Note: Tests passed