### PR TITLE
chore: Update WorkOS integration README with Redirect URI & CORS Setup instructions

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/workos/README.md
+++ b/packages/create/src/frameworks/react/add-ons/workos/README.md
@@ -1,4 +1,4 @@
 ## Setting up WorkOS
 
 - Set the `VITE_WORKOS_CLIENT_ID` in your `.env.local`.
-- In the WorkOS dashboard, add http://localhost:3000 to Cross-Origin Resource Sharing (CORS) Allowed Origins
+- In the WorkOS dashboard, add `http://localhost:3000` to Redirect URIs, and Cross-Origin Resource Sharing (CORS) Allowed Origins

--- a/packages/create/src/frameworks/react/add-ons/workos/README.md
+++ b/packages/create/src/frameworks/react/add-ons/workos/README.md
@@ -1,3 +1,4 @@
 ## Setting up WorkOS
 
 - Set the `VITE_WORKOS_CLIENT_ID` in your `.env.local`.
+- In the WorkOS dashboard, add http://localhost:3000 to Cross-Origin Resource Sharing (CORS) Allowed Origins


### PR DESCRIPTION
# Problem
When creating a new TanStack Start app from the CLI and selecting the WorkOS integration, there are additional undocumented steps required to get up and running with a WorkOS application. The `Redirect URI` and `CORS Allowed Origin` must be set within WorkOS. 

If the user does not set the redirect URI, WorkOS properly warns that the `Redirect URI` is invalid - this should be enough feedback to the user to correct this, but is a little bit clunky of a new app flow.

If the user does not set the CORS Allowed Origin, the authentication silently fails in the example app created by TanStack. This can be slightly challenging to debug for newer users.

CORS Allowed Origins can be found in the WorkOS dashboard via searching "CORS", or navigating to Authentication -> Sessions -> Cross-Origin Resource Sharing (CORS) and adding `http://localhost:3000` as an allowed origin.


# Reproduction steps
- Progress through a fresh WorkOS Workspace/Team setup 
- Use the TanStack CLI to create a Start application with prompts (`tanstack create`). 
  - Choose "No" for `Would you like to include demo/example pages?`
  - Select the "WorkOS" add-on when prompted
- After project creation, you are prompted to view the README.md. There is no mention in the WorkOS section to set the Redirect URI or CORS Allowed Origin for development
- Add your WorkOS Client ID to `.env.local`
- Run `pnpm dev` to test the application, navigate your browser to `localhost:3000`
- Attempt to perform a sign in with button in the header. You will be prompted by WorkOS to sign-in.
- WorkOS redirects. **`Invalid Redirect URI`** errors here by WorkOS, if applicable
- Back on the app page, the button still shows "Sign In". Subsequent clicks do not prompt another WorkOS sign-in, but presumably attempt to use the cookie and silently fail.
- Server-side dev console logs an empty object when performing the sign-in. 
 

# Solution
This PR adds a single line to the integrations README as a callout to set these parameters within WorkOS. This cleans up the development onboarding flow for the WorkOS add-on.