### PR TITLE
Remove redundant box-sizing rule

### DIFF
--- a/packages/create/src/frameworks/react/project/base/src/styles.css.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/styles.css.ejs
@@ -74,10 +74,6 @@
   }
 }
 
-* {
-  box-sizing: border-box;
-}
-
 html,
 body,
 #app {


### PR DESCRIPTION
Hello, after scaffolding a router project, the generated app includes a [redundant box-sizing rule](https://github.com/TanStack/cli/blob/main/packages/create/src/frameworks/react/project/base/src/styles.css.ejs#L77). Tailwind already applies box-sizing in the base layer via its [preflight styles](https://tailwindcss.com/docs/preflight#border-styles-are-reset). This doesn’t really affect styling, but it does create unnecessary noise in the devtools.

<img width="520" height="179" alt="image" src="https://github.com/user-attachments/assets/97d17192-2e6f-403e-8cf7-8c53e31023f5" />

Cheers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the default styling rules in the project template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->