### PR TITLE
fix: useeffect should not return subscription object

### DIFF
--- a/packages/create/src/frameworks/react/examples/events/assets/src/components/RemyAssistant.tsx
+++ b/packages/create/src/frameworks/react/examples/events/assets/src/components/RemyAssistant.tsx
@@ -91,7 +91,7 @@ export default function RemyAssistant({
 
   // Sync with store for header control
   useEffect(() => {
-    return showRemyAssistant.subscribe(() => {
+    showRemyAssistant.subscribe(() => {
       setIsOpen(showRemyAssistant.state)
     })
   }, [])


### PR DESCRIPTION
This PR fixes an issue with useEffect hook faulty returning a subscription object;
useEffect should not return, unless a cleanup function.

Current implication of return is that navigating to "Meet Our Speakers" from the tryout example starting page, results
in a crash-landing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state synchronization handling in the Assistant component to ensure proper effect cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->