### PR TITLE
fix: tanstack query integration

### DIFF
--- a/.changeset/soft-corners-allow.md
+++ b/.changeset/soft-corners-allow.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/create': patch
+---
+
+Fix Tanstack Query Integration

--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -25,18 +25,7 @@ export const trpcClient = createTRPCClient<TRPCRouter>({
   ],
 });
 
-let context:
-  | {
-      queryClient: QueryClient
-      trpc: ReturnType<typeof createTRPCOptionsProxy<TRPCRouter>>
-    }
-  | undefined
-
 export function getContext() {
-  if (context) {
-    return context
-  }
-
   const queryClient = new QueryClient({
     defaultOptions: {
       dehydrate: { serializeData: superjson.serialize },
@@ -58,10 +47,12 @@ export function getContext() {
 
 export default function TanStackQueryProvider({
   children,
+  context,
 }: {
-  children: ReactNode
+  children: ReactNode,
+  context: ReturnType<typeof getContext>
 }) {
-  const { queryClient } = getContext()
+  const { queryClient } = context
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -75,32 +66,22 @@ export default function TanStackQueryProvider({
 import type { ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-let context:
-  | {
-      queryClient: QueryClient
-    }
-  | undefined
-
 export function getContext() {
-  if (context) {
-    return context
-  }
-
   const queryClient = new QueryClient();
 
-  context = {
+  return {
     queryClient,
   }
-
-  return context
 }
 
 export default function TanStackQueryProvider({
   children,
+  context,
 }: {
   children: ReactNode
+  context: ReturnType<typeof getContext>
 }) {
-  const { queryClient } = getContext()
+  const { queryClient } = context
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -62,31 +62,4 @@ export default function TanStackQueryProvider({
     </QueryClientProvider>
   )
 }
-<% } else { %>
-import type { ReactNode } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-
-export function getContext() {
-  const queryClient = new QueryClient();
-
-  return {
-    queryClient,
-  }
-}
-
-export default function TanStackQueryProvider({
-  children,
-  context,
-}: {
-  children: ReactNode
-  context: ReturnType<typeof getContext>
-}) {
-  const { queryClient } = context
-
-  return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-    </QueryClientProvider>
-  )
-}
 <% } %>

--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -37,7 +37,7 @@ export function getContext() {
     client: trpcClient,
     queryClient: queryClient,
   });
-  context = {
+  const context = {
     queryClient,
     trpc: serverHelpers,
   }
@@ -45,7 +45,7 @@ export function getContext() {
   return context
 }
 
-export default function TanStackQueryProvider({
+export default function TanstackQueryProvider({
   children,
   context,
 }: {
@@ -55,11 +55,20 @@ export default function TanStackQueryProvider({
   const { queryClient } = context
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-        {children}
-      </TRPCProvider>
-    </QueryClientProvider>
+    <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+      {children}
+    </TRPCProvider>
   )
 }
+<% } else { %>
+import { QueryClient } from '@tanstack/react-query'
+
+export function getContext() {
+  const queryClient = new QueryClient();
+
+  return {
+    queryClient,
+  }
+}
+export default function TanstackQueryProvider() {}
 <% } %>

--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/info.json
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/info.json
@@ -19,11 +19,6 @@
   ],
   "integrations": [
     {
-      "type": "provider",
-      "path": "src/integrations/tanstack-query/root-provider.tsx",
-      "jsName": "TanStackQueryProvider"
-    },
-    {
       "type": "devtools",
       "path": "src/integrations/tanstack-query/devtools.tsx",
       "jsName": "TanStackQueryDevtools"

--- a/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
@@ -1,27 +1,38 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 <% if (addOnEnabled['tanstack-query']) { %>
+import type { ReactNode } from 'react'
 import { QueryClient } from '@tanstack/react-query'
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
+import TanstackQueryProvider, { getContext } from './integrations/tanstack-query/root-provider'
 <% } %>
 
 export function getRouter() {
   <% if (addOnEnabled['tanstack-query']) { %>
-  const queryClient = new QueryClient();
+  const context = getContext();
   <% } %>
-
+  
   const router = createTanStackRouter({
     routeTree,<% if (addOnEnabled['tanstack-query']) { %>
-    context: { queryClient },<% } else if (addOnEnabled['apollo-client']) { %>
+    context,<% } else if (addOnEnabled['apollo-client']) { %>
     context: {} as any,
 <% } %>
     scrollRestoration: true,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
+    <% if (addOnEnabled.tRPC) { %>
+    Wrap: (props: { children: ReactNode }) => {
+      return (
+        <TanstackQueryProvider context={context}>
+            {props.children}
+        </TanstackQueryProvider>
+        );
+      },
+    <% } %>
   })
 
 <% if (addOnEnabled['tanstack-query']) { %>
-  setupRouterSsrQueryIntegration({ router, queryClient: queryClient })
+  setupRouterSsrQueryIntegration({ router, queryClient: context.queryClient })
 <% } %>
 
   return router

--- a/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
@@ -1,40 +1,27 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 <% if (addOnEnabled['tanstack-query']) { %>
+import { QueryClient } from '@tanstack/react-query'
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
-import TanStackQueryProvider, {
-  getContext,
-} from "./integrations/tanstack-query/root-provider";
 <% } %>
 
 export function getRouter() {
   <% if (addOnEnabled['tanstack-query']) { %>
-  const context = getContext();
+  const queryClient = new QueryClient();
   <% } %>
 
   const router = createTanStackRouter({
-    routeTree,
-<% if (addOnEnabled['tanstack-query']) { %>
-    context,
-<% } else if (addOnEnabled['apollo-client']) { %>
+    routeTree,<% if (addOnEnabled['tanstack-query']) { %>
+    context: { queryClient },<% } else if (addOnEnabled['apollo-client']) { %>
     context: {} as any,
 <% } %>
     scrollRestoration: true,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
-<% if (addOnEnabled['tanstack-query']) { %>
-    Wrap: (props: { children: React.ReactNode }) => {
-      return (
-        <TanStackQueryProvider context={context}>
-          {props.children}
-        </TanStackQueryProvider>
-      );
-    },
-<% } %> 
   })
 
 <% if (addOnEnabled['tanstack-query']) { %>
-  setupRouterSsrQueryIntegration({ router, queryClient: context.queryClient })
+  setupRouterSsrQueryIntegration({ router, queryClient: queryClient })
 <% } %>
 
   return router

--- a/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
@@ -1,21 +1,41 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 <% if (addOnEnabled['tanstack-query']) { %>
-import { getContext } from './integrations/tanstack-query/root-provider'
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
+import TanStackQueryProvider, {
+  getContext,
+} from "./integrations/tanstack-query/root-provider";
 <% } %>
 
 export function getRouter() {
+  <% if (addOnEnabled['tanstack-query']) { %>
+  const context = getContext();
+  <% } %>
+
   const router = createTanStackRouter({
     routeTree,
 <% if (addOnEnabled['tanstack-query']) { %>
-    context: getContext(),
+    context,
 <% } else if (addOnEnabled['apollo-client']) { %>
     context: {} as any,
 <% } %>
     scrollRestoration: true,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
+<% if (addOnEnabled['tanstack-query']) { %>
+    Wrap: (props: { children: React.ReactNode }) => {
+      return (
+        <TanStackQueryProvider context={context}>
+          {props.children}
+        </TanStackQueryProvider>
+      );
+    },
+<% } %> 
   })
+
+<% if (addOnEnabled['tanstack-query']) { %>
+  setupRouterSsrQueryIntegration({ router, queryClient: context.queryClient })
+<% } %>
 
   return router
 }


### PR DESCRIPTION
Tested locally with 

`node ./cli/packages/cli/dist/index.js create my-app3 --add-ons tanstack-query`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Query client is created earlier during router setup and passed into the app for SSR integration.
  * Server-side query integration is registered during router creation for improved SSR behavior.
  * TanStack Query provider simplified: when RPC is enabled it now accepts an explicit context prop; otherwise the provider surface is reduced.

* **Chores**
  * Provider integration entry removed from add-on metadata, leaving only the devtools integration.
  * Added a patch changeset for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->