### PR TITLE
fix(create): missing header/footer in router template

### DIFF
--- a/packages/create/src/frameworks/react/project/base/src/routes/__root.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/routes/__root.tsx.ejs
@@ -2,6 +2,8 @@
 import { Outlet, createRootRoute } from '@tanstack/react-router'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 import { TanStackDevtools } from '@tanstack/react-devtools'
+import Footer from '../components/Footer'
+import Header from '../components/Header'
 
 import '../styles.css'
 
@@ -12,7 +14,9 @@ export const Route = createRootRoute({
 function RootComponent() {
   return (
     <>
+      <Header />
       <Outlet />
+      <Footer />
       <TanStackDevtools
         config={{
           position: 'bottom-right',


### PR DESCRIPTION
They seems to have been removed in february's refactoring. Without the header/footer the quick start instructions on the index page (ex: "_Update src/components/Header.tsx and src/components/Footer.tsx for brand links._") makes little sense.

edit: I disagree with CodeRabbit that this is a new feature. That's a bug fix since those header/footer were present initially.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default React project template to include Header and Footer components in the root layout. These components are now automatically rendered at the top and bottom of all application content, establishing a consistent UI structure for newly created React projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->