### PR TITLE
fix(create): upgrade to Vite 8 and fix useStore selector in AI add-on

### DIFF
--- a/.changeset/vite8-usestore-fix.md
+++ b/.changeset/vite8-usestore-fix.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/create': patch
+---
+
+Upgrade to Vite 8 and replace `vite-tsconfig-paths` plugin with native `resolve.tsconfigPaths` option. Fix `useStore` call in AI assistant add-on to pass required selector function.

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
@@ -79,7 +79,7 @@ function Messages({ messages }: { messages: ChatMessages }) {
 }
 
 export default function AIAssistant() {
-  const isOpen = useStore(showAIAssistant)
+  const isOpen = useStore(showAIAssistant, (state) => state)
   const { messages, sendMessage } = useGuitarRecommendationChat()
   const [input, setInput] = useState('')
 

--- a/packages/create/src/frameworks/react/project/base/package.json
+++ b/packages/create/src/frameworks/react/project/base/package.json
@@ -28,14 +28,16 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "^28.1.0",
     "typescript": "^5.9.2",
-    "vite": "^7.3.1",
-    "vite-tsconfig-paths": "^5.1.4",
+    "vite": "^8.0.0",
     "vitest": "^3.0.5"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "lightningcss"]
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "lightningcss"
+    ]
   }
 }

--- a/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
+++ b/packages/create/src/frameworks/react/project/base/vite.config.ts.ejs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite'
 import { devtools } from '@tanstack/devtools-vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 <% if (addOnEnabled.paraglide) { -%>
 import { paraglideVitePlugin } from "@inlang/paraglide-js"
 <% } -%>
@@ -15,12 +14,12 @@ import tailwindcss from "@tailwindcss/vite"
 <% } %>
 
 const config = defineConfig({
+  resolve: { tsconfigPaths: true },
   plugins: [devtools(), <% if (addOnEnabled.paraglide) { %>paraglideVitePlugin({
     project: './project.inlang',
     outdir: './src/paraglide',
     strategy: ['url', "baseLocale"],
   }), <% } %><% for(const integration of integrations.filter(i => i.type === 'vite-plugin')) { %><%- integrationImportCode(integration) %>,<% } %>
-    tsconfigPaths({ projects: ['./tsconfig.json'] }),
     tailwindcss(),
     <% if (routerOnly) { %>tanstackRouter({ target: 'react', autoCodeSplitting: true }),<% } else { %>tanstackStart(),<% } %>
     viteReact(<% if (addOnEnabled.compiler) { %>{


### PR DESCRIPTION
## Summary

- **Upgrade to Vite 8**: Bumps `vite` from `^7.3.1` to `^8.0.0` and `@vitejs/plugin-react` from `^5.1.4` to `^6.0.1`
- **Remove `vite-tsconfig-paths`**: Replaced with Vite 8's native `resolve: { tsconfigPaths: true }` option, eliminating an extra dependency
- **Fix `useStore` crash in AI add-on**: The `useStore` call in `demo-AIAssistant.tsx` was missing the required selector function, causing a `TypeError: selector is not a function` at runtime. Added `(state) => state` as the selector.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` (unit + e2e) all green
- [x] Verified manually with `node packages/cli/dist/index.js dev test-app --framework React --add-ons ai`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Upgraded Vite from v7.3.1 to v8.0.0
  * Updated @vitejs/plugin-react from v5.1.4 to v6.0.1
  * Removed vite-tsconfig-paths dependency

* **Configuration Updates**
  * Switched from the external vite-tsconfig-paths plugin to Vite's native built-in TypeScript path resolution configuration

* **Bug Fixes**
  * Corrected the AI assistant component's store state selection to properly initialize component state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->