### PR TITLE
fix(create): exclude demo files in lib, hooks, data, and components when demo / examples are disabled

### DIFF
--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -17,14 +17,22 @@ import { runSpecialSteps } from './special-steps/index.js'
 
 import type { Environment, FileBundleHandler, Options } from './types.js'
 
-function isDemoRoutePath(path?: string) {
+function isDemoFilePath(path?: string) {
   if (!path) return false
   const normalized = path.replace(/\\/g, '/')
   return (
     normalized.includes('/routes/demo/') ||
     normalized.includes('/routes/demo.') ||
     normalized.includes('/routes/example/') ||
-    normalized.includes('/routes/example.')
+    normalized.includes('/routes/example.') ||
+    normalized.includes('/lib/demo-') ||
+    normalized.includes('/lib/demo.') ||
+    normalized.includes('/hooks/demo-') ||
+    normalized.includes('/hooks/demo.') ||
+    normalized.includes('/data/demo.') ||
+    normalized.includes('/data/demo-') ||
+    normalized.includes('/components/demo-') ||
+    normalized.includes('/components/demo.')
   )
 }
 
@@ -38,7 +46,7 @@ function stripExamplesFromOptions(options: Options): Options {
     .map((addOn) => {
       const filteredRoutes = (addOn.routes || []).filter(
         (route) =>
-          !isDemoRoutePath(route.path) &&
+          !isDemoFilePath(route.path) &&
           !(route.url && route.url.startsWith('/demo')),
       )
 
@@ -47,11 +55,11 @@ function stripExamplesFromOptions(options: Options): Options {
         routes: filteredRoutes,
         getFiles: async () => {
           const files = await addOn.getFiles()
-          return files.filter((file) => !isDemoRoutePath(file))
+          return files.filter((file) => !isDemoFilePath(file))
         },
         getDeletedFiles: async () => {
           const deletedFiles = await addOn.getDeletedFiles()
-          return deletedFiles.filter((file) => !isDemoRoutePath(file))
+          return deletedFiles.filter((file) => !isDemoFilePath(file))
         },
       }
     })


### PR DESCRIPTION
Previously only demo route files were filtered out when the user chose no demo files. Demo files in components/, lib/, hooks/, and data/ directories would still be created. Rename isDemoRoutePath to isDemoFilePath to reflect the broader scope and extend pattern matching to cover all non-route demo file paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filtering of example and demo files during app creation to ensure comprehensive removal across all project locations, including libraries, hooks, data, and components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->