### PR TITLE
feat(create): add OXC toolchain (oxlint + oxfmt)

### DIFF
--- a/.changeset/add-oxc-toolchain.md
+++ b/.changeset/add-oxc-toolchain.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/create": patch
+---
+
+feat: add OXC toolchain (oxlint + oxfmt) for React and Solid frameworks

--- a/packages/create/src/frameworks/react/toolchains/oxc/assets/_dot_oxfmtrc.json
+++ b/packages/create/src/frameworks/react/toolchains/oxc/assets/_dot_oxfmtrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/create/src/frameworks/react/toolchains/oxc/assets/_dot_oxlintrc.json
+++ b/packages/create/src/frameworks/react/toolchains/oxc/assets/_dot_oxlintrc.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["react"],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  },
+  "env": {
+    "browser": true,
+    "node": true
+  }
+}

--- a/packages/create/src/frameworks/react/toolchains/oxc/info.json
+++ b/packages/create/src/frameworks/react/toolchains/oxc/info.json
@@ -1,0 +1,12 @@
+{
+  "name": "OXC",
+  "description": "OXC toolchain support (oxlint + oxfmt).",
+  "phase": "setup",
+  "type": "toolchain",
+  "category": "tooling",
+  "exclusive": ["linter"],
+  "color": "#FF5A1F",
+  "priority": 3,
+  "modes": ["code-router", "file-router"],
+  "link": "https://oxc.rs"
+}

--- a/packages/create/src/frameworks/react/toolchains/oxc/package.json
+++ b/packages/create/src/frameworks/react/toolchains/oxc/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "lint": "oxlint .",
+    "format": "oxfmt --check .",
+    "check": "oxfmt --write . && oxlint --fix ."
+  },
+  "devDependencies": {
+    "oxlint": "^1.0.0",
+    "oxfmt": "^0.46.0"
+  }
+}

--- a/packages/create/src/frameworks/react/toolchains/oxc/small-logo.svg
+++ b/packages/create/src/frameworks/react/toolchains/oxc/small-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="8" fill="#FF5A1F"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="20" fill="#fff">OXC</text>
+</svg>

--- a/packages/create/src/frameworks/solid/toolchains/oxc/assets/_dot_oxfmtrc.json
+++ b/packages/create/src/frameworks/solid/toolchains/oxc/assets/_dot_oxfmtrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/create/src/frameworks/solid/toolchains/oxc/assets/_dot_oxlintrc.json
+++ b/packages/create/src/frameworks/solid/toolchains/oxc/assets/_dot_oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "error"
+  },
+  "env": {
+    "browser": true,
+    "node": true
+  }
+}

--- a/packages/create/src/frameworks/solid/toolchains/oxc/info.json
+++ b/packages/create/src/frameworks/solid/toolchains/oxc/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "OXC",
+  "description": "OXC toolchain support (oxlint + oxfmt).",
+  "phase": "setup",
+  "type": "toolchain",
+  "category": "tooling",
+  "exclusive": ["linter"],
+  "color": "#FF5A1F",
+  "modes": ["code-router", "file-router"],
+  "link": "https://oxc.rs"
+}

--- a/packages/create/src/frameworks/solid/toolchains/oxc/package.json
+++ b/packages/create/src/frameworks/solid/toolchains/oxc/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "lint": "oxlint .",
+    "format": "oxfmt --check .",
+    "check": "oxfmt --write . && oxlint --fix ."
+  },
+  "devDependencies": {
+    "oxlint": "^1.0.0",
+    "oxfmt": "^0.46.0"
+  }
+}

--- a/packages/create/src/frameworks/solid/toolchains/oxc/small-logo.svg
+++ b/packages/create/src/frameworks/solid/toolchains/oxc/small-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="8" fill="#FF5A1F"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="20" fill="#fff">OXC</text>
+</svg>


### PR DESCRIPTION
## Summary

- Adds **OXC** as a third toolchain option alongside ESLint and Biome for both React and Solid frameworks
- [OXC](https://oxc.rs) is a Rust-powered toolchain from the oxc-project: **oxlint** (linter) + **oxfmt** (formatter)
- oxlint is 10–100× faster than ESLint; oxfmt is 30× faster than Prettier and passes 100% of Prettier's JS/TS conformance tests

## Changes

New files only — no existing code modified. Auto-discovered by `scanAddOnDirectories` (no TypeScript registration needed).

**React** `packages/create/src/frameworks/react/toolchains/oxc/`
**Solid** `packages/create/src/frameworks/solid/toolchains/oxc/`

Each contains:
- `info.json` — type `toolchain`, `exclusive: ["linter"]`, priority 3 (after ESLint=0, Biome=2)
- `package.json` — `oxlint ^1.0.0`, `oxfmt ^0.46.0`, with `lint`/`format`/`check` scripts
- `assets/.oxlintrc.json` — minimal correctness rules; React variant adds `react` plugin
- `assets/.oxfmtrc.json` — Prettier-compatible formatting config
- `small-logo.svg` — OXC brand orange (#FF5A1F)

## Test plan

```bash
pnpm install && pnpm build

# From a peer directory
node ../cli/packages/cli/dist/index.js create test-oxc --toolchain oxc

# In generated app, verify:
# - .oxlintrc.json and .oxfmtrc.json exist
# - package.json has oxlint + oxfmt devDeps and lint/format/check scripts
# - npm run lint / format / check all work
```

## Notes

- oxfmt is currently beta (v0.x) but passes 100% of Prettier's JS/TS tests as of the Feb 2026 beta release — flagging for maintainer awareness
- The 2 pre-existing Windows path test failures (`file-helper.test.ts`, `create-app.test.ts`) exist on `main` and are unrelated to this PR; CI (Linux) passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OXC toolchain support for React and Solid projects with integrated linting (oxlint) and code formatting (oxfmt)
  * Includes lint, format, and check commands to enforce code quality and consistency standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->