### PR TITLE
fix(cli): surface keyboard controls on add-on multiselect prompt

### DIFF
--- a/.changeset/multiselect-keyboard-hint.md
+++ b/.changeset/multiselect-keyboard-hint.md
@@ -1,0 +1,16 @@
+---
+'@tanstack/cli': patch
+---
+
+fix(cli): make add-on multiselect keyboard controls discoverable
+
+Users encountering the add-on multiselect prompt during `tanstack create`
+often didn't realize the entries are checkboxes (toggle with Space) and
+that the selection must be confirmed with Enter. The existing keyboard
+shortcuts note was only shown once per session and could appear before
+single-select prompts where it didn't apply. Now:
+
+- The "Keyboard Shortcuts" note is shown immediately above every
+  multiselect prompt and is no longer shown before single-select prompts.
+- The multiselect message itself includes an inline `(Space to toggle,
+  Enter to confirm)` hint so the cue is inseparable from the prompt.

--- a/packages/cli/src/ui-prompts.ts
+++ b/packages/cli/src/ui-prompts.ts
@@ -133,9 +133,6 @@ export async function selectTemplate(
   return selected
 }
 
-// Track if we've shown the multiselect help text
-let hasShownMultiselectHelp = false
-
 export async function selectAddOns(
   framework: Framework,
   mode: string,
@@ -150,15 +147,6 @@ export async function selectAddOns(
     return []
   }
 
-  // Show help text only once
-  if (!hasShownMultiselectHelp) {
-    note(
-      'Use ↑/↓ to navigate • Space to select/deselect • Enter to confirm',
-      'Keyboard Shortcuts',
-    )
-    hasShownMultiselectHelp = true
-  }
-
   if (allowMultiple) {
     const selectableAddOns = addOns.filter(
       (addOn) => !forcedAddOns.includes(addOn.id),
@@ -168,13 +156,18 @@ export async function selectAddOns(
       return []
     }
 
+    note(
+      'Use ↑/↓ to navigate • Space to select/deselect • Enter to confirm',
+      'Keyboard Shortcuts',
+    )
+
     const value = await multiselect({
-      message,
+      message: `${message} (Space to toggle, Enter to confirm)`,
       options: selectableAddOns.map((addOn) => ({
-          value: addOn.id,
-          label: addOn.name,
-          hint: addOn.description,
-        })),
+        value: addOn.id,
+        label: addOn.name,
+        hint: addOn.description,
+      })),
       maxItems: selectableAddOns.length,
       required: false,
     })


### PR DESCRIPTION
## Summary

Users reported not realizing the add-on selector during `tanstack create` is a checkbox list (Space toggles) that needs Enter to confirm. The existing keyboard hint was shown only once per session and could appear before single-select prompts where it didn't apply.

- Show the "Keyboard Shortcuts" note immediately above **every** multiselect prompt (no longer once-only, no longer before single-selects).
- Append `(Space to toggle, Enter to confirm)` directly to the multiselect message so the cue is inseparable from the prompt itself.

Result:

\`\`\`
┌  Keyboard Shortcuts
│  Use ↑/↓ to navigate • Space to select/deselect • Enter to confirm
└

◆  What add-ons would you like for your project? (Space to toggle, Enter to confirm)
│  ◯ Clerk
│  ◯ Drizzle
│  ...
\`\`\`

## Test plan

- [x] \`vitest run tests/ui-prompts.test.ts\` — 14/14 pass
- [x] \`tsc --noEmit\` — clean
- [x] Pre-commit hook (lint, type, unit, e2e blocking) — passed
- [ ] Manual smoke: \`tanstack create my-app\` and confirm the hint shows above the add-on prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard shortcuts help text now displays consistently above every multiselect prompt instead of appearing only once
  * Added inline keyboard hint "(Space to toggle, Enter to confirm)" to multiselect prompts for clearer user guidance
  * Removed redundant keyboard shortcuts display from single-select prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->