### PR TITLE
chore: add changeset for PowerSync add-on

### DIFF
--- a/.changeset/powersync-addon.md
+++ b/.changeset/powersync-addon.md
@@ -1,0 +1,24 @@
+---
+'@tanstack/cli': minor
+'@tanstack/create': minor
+---
+
+feat(create): add React PowerSync scaffolding add-on
+
+`tanstack add powersync` (or `--add-ons powersync` on `tanstack create`)
+wires the PowerSync Web SDK into a React TanStack Start app:
+
+- `@powersync/web` + `@powersync/react` + `@journeyapps/wa-sqlite`
+  dependencies and a Vite plugin that excludes `@powersync/web` from
+  `optimizeDeps` and emits ES-module workers (required for the
+  WA-SQLite VFS).
+- A `PowerSyncProvider` integration that opens a WA-SQLite database
+  and connects with `disableSSRWarning` so SSR doesn't warn.
+- A sample `AppSchema` (todos table) and `BackendConnector` with
+  `fetchCredentials` reading `VITE_POWERSYNC_URL` / `VITE_POWERSYNC_TOKEN`
+  from `.env.local` and a stubbed `uploadData()` ready for the user's
+  upstream write logic.
+- A `/demo/powersync` route that inserts rows locally and renders
+  live `useQuery` results plus connection status, so the scaffold
+  works zero-config and shows the SDK is wired up before any
+  PowerSync instance is configured.


### PR DESCRIPTION
## Summary

- Adds the missing changeset for [#407](https://github.com/TanStack/cli/pull/407) (React PowerSync scaffolding add-on, merged as 8f24af5f) so the next Version Packages release publishes it.
- Minor bump for `@tanstack/cli` and `@tanstack/create`.

## Verification

Locally scaffolded a fresh app with the add-on and confirmed the integration is wired up end-to-end:

```
node packages/cli/dist/index.js create powersync-test --framework react --add-ons powersync --no-git --no-intent -y
cd powersync-test
npx tsc --noEmit            # clean
npm run build               # client + SSR succeed
npm run dev -- --port 4567  # SSR serves /demo/powersync → HTTP 200
```

The Vite plugin excludes `@powersync/web` from `optimizeDeps` (required for the WA-SQLite VFS), the `PowerSyncProvider` opens the DB with `disableSSRWarning`, the sample `AppSchema`/`BackendConnector` read `VITE_POWERSYNC_URL`/`VITE_POWERSYNC_TOKEN` from `.env.local`, and `/demo/powersync` inserts local rows + renders live `useQuery` results without any real PowerSync instance configured.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` (pre-commit hook)
- [x] Scaffolded React + PowerSync app builds and SSR-renders `/demo/powersync`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added PowerSync add-on scaffolding via `tanstack add powersync` command or `--add-ons powersync` flag for TanStack Create
* Automatically integrates PowerSync Web SDK into React applications with sample demo route and live query support

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/cli/pull/448)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->