### PR TITLE
Fix AI assistant demo panel placement

### DIFF
--- a/.changeset/flat-ai-assistant.md
+++ b/.changeset/flat-ai-assistant.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/create": patch
+---
+
+Keep the generated AI assistant demo panel inside the viewport.

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
@@ -97,7 +97,7 @@ export default function AIAssistant() {
       </button>
 
       {isOpen && (
-        <div className="absolute bottom-0 left-full ml-2 w-[700px] h-[600px] bg-gray-900 rounded-lg shadow-xl border border-orange-500/20 flex flex-col">
+        <div className="fixed inset-x-4 top-20 z-[100] flex h-[calc(100vh-6rem)] max-h-[600px] flex-col overflow-hidden rounded-lg border border-orange-500/20 bg-gray-900 shadow-xl sm:left-auto sm:w-[min(calc(100vw-2rem),700px)]">
           <div className="flex items-center justify-between p-3 border-b border-orange-500/20">
             <h3 className="font-semibold text-white">AI Assistant</h3>
             <button


### PR DESCRIPTION
## Summary

Fixes the generated React AI add-on header assistant so the opened chat panel stays inside the viewport. The panel previously opened with `left-full` from the header button and a fixed `700px` width, which could push the input and send button off-screen.

This changes the panel to a fixed, viewport-bound overlay with responsive width and height. It also adds a patch changeset for `@tanstack/create`.

## Validation

- `pnpm --filter @tanstack/create build`
- `pnpm --filter @tanstack/create test`
- `pnpm --filter @tanstack/create exec prettier --check src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx`
- Commit hook: `nx run-many --target=build --parallel 5`
- Commit hook: `pnpm test:unit && pnpm test:e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AI assistant demo panel so it stays within the viewport and no longer overflows screen bounds.

* **Style**
  * Updated assistant panel layout to use fixed positioning with responsive sizing for different viewports.
  * Added height constraints and overflow handling to improve display and scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->