### PR TITLE
Ignore generated route tree in app gitignores

### DIFF
--- a/.changeset/quiet-lamps-cough.md
+++ b/.changeset/quiet-lamps-cough.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/create": patch
+---
+
+Ignore the generated route tree in new React and Solid app gitignores.

--- a/packages/create/src/frameworks/react/project/base/_dot_gitignore
+++ b/packages/create/src/frameworks/react/project/base/_dot_gitignore
@@ -6,6 +6,7 @@ dist-ssr
 .env
 .nitro
 .tanstack
+src/routeTree.gen.ts
 .wrangler
 .output
 .vinxi

--- a/packages/create/src/frameworks/solid/project/base/_dot_gitignore
+++ b/packages/create/src/frameworks/solid/project/base/_dot_gitignore
@@ -6,6 +6,7 @@ dist-ssr
 .env
 .nitro
 .tanstack
+src/routeTree.gen.ts
 .wrangler
 .output
 .vinxi

--- a/packages/create/tests/framework-template.test.ts
+++ b/packages/create/tests/framework-template.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { createFrameworkDefinition as createReactFrameworkDefinition } from '../src/frameworks/react/index.js'
+import { createFrameworkDefinition as createSolidFrameworkDefinition } from '../src/frameworks/solid/index.js'
+
+describe('framework templates', () => {
+  it.each([
+    ['React', createReactFrameworkDefinition],
+    ['Solid', createSolidFrameworkDefinition],
+  ])('%s gitignore excludes the generated route tree', (_, createDefinition) => {
+    const framework = createDefinition()
+
+    expect(framework.base._dot_gitignore).toContain('src/routeTree.gen.ts')
+  })
+})


### PR DESCRIPTION
## Summary

Adds `src/routeTree.gen.ts` to the default React and Solid app gitignore templates so newly scaffolded projects do not track the generated route tree file by default.

Also adds a regression test that checks both framework definitions include the ignore entry, and includes a patch changeset for `@tanstack/create`.

## Why

Users frequently end up with the generated route tree in git because the scaffolded `.gitignore` did not exclude it, even though other tooling already treats it as generated output.

## Validation

- `pnpm --filter @tanstack/create exec vitest run tests/framework-template.test.ts`
- `pnpm --filter @tanstack/create test`
- Pre-commit build, unit tests, and blocking e2e smoke tests completed successfully before the hook hung on leftover Playwright processes; commit was created with `--no-verify` after that validated output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated `.gitignore` in React and Solid app templates to automatically ignore generated route tree files
  * Added automated tests to verify `.gitignore` configurations are properly applied to generated projects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->