### PR TITLE
Track generated route tree in scaffolds

### DIFF
--- a/.changeset/track-route-tree.md
+++ b/.changeset/track-route-tree.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/create": patch
+---
+
+Keep the generated route tree tracked in new React and Solid apps and run route generation once during scaffold.

--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -31,7 +31,7 @@ function stripExamplesFromOptions(options: Options): Options {
           !isDemoFilePath(route.path) &&
           !(route.url && route.url.startsWith('/demo')),
       )
-      
+
       const filteredIntegrations = (addOn.integrations || []).filter(
         (integration) => !isDemoFilePath(integration.path)
       )
@@ -277,6 +277,37 @@ async function runCommandsAndInstallDependencies(
   await installShadcnComponents(environment, options.targetDir, options)
 
   await setupIntent(environment, options.targetDir, options)
+
+  if (shouldGenerateRoutes(options)) {
+    s.start(`Generating route tree...`)
+    const command = getPackageManagerScriptCommand(options.packageManager, [
+      'generate-routes',
+    ])
+    const cmd = formatCommand(command)
+    environment.startStep({
+      id: 'generate-routes',
+      type: 'command',
+      message: cmd,
+    })
+    await environment.execute(
+      command.command,
+      command.args,
+      options.targetDir,
+      {
+        inherit: true,
+      },
+    )
+    environment.finishStep('generate-routes', 'Route tree generated')
+    s.stop(`Route tree generated`)
+  }
+}
+
+function shouldGenerateRoutes(options: Options) {
+  return (
+    options.install !== false &&
+    options.mode === 'file-router' &&
+    (options.framework.id === 'react' || options.framework.id === 'solid')
+  )
 }
 
 async function seedEnvValues(environment: Environment, options: Options) {

--- a/packages/create/src/frameworks/react/project/base/_dot_gitignore
+++ b/packages/create/src/frameworks/react/project/base/_dot_gitignore
@@ -6,7 +6,6 @@ dist-ssr
 .env
 .nitro
 .tanstack
-src/routeTree.gen.ts
 .wrangler
 .output
 .vinxi

--- a/packages/create/src/frameworks/react/project/base/package.json
+++ b/packages/create/src/frameworks/react/project/base/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "dev": "vite dev --port 3000",
+    "generate-routes": "tsr generate",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run"

--- a/packages/create/src/frameworks/react/project/base/tsr.config.json
+++ b/packages/create/src/frameworks/react/project/base/tsr.config.json
@@ -1,0 +1,3 @@
+{
+  "target": "react"
+}

--- a/packages/create/src/frameworks/react/project/packages.json
+++ b/packages/create/src/frameworks/react/project/packages.json
@@ -15,6 +15,9 @@
     }
   },
   "file-router": {
+    "devDependencies": {
+      "@tanstack/router-cli": "^1.132.0"
+    },
     "dependencies": {
       "@tanstack/router-plugin": "^1.132.0"
     }

--- a/packages/create/src/frameworks/solid/project/base/_dot_gitignore
+++ b/packages/create/src/frameworks/solid/project/base/_dot_gitignore
@@ -6,7 +6,6 @@ dist-ssr
 .env
 .nitro
 .tanstack
-src/routeTree.gen.ts
 .wrangler
 .output
 .vinxi

--- a/packages/create/src/frameworks/solid/project/base/package.json
+++ b/packages/create/src/frameworks/solid/project/base/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3000",
+    "generate-routes": "tsr generate",
     "build": "vite build",
     "start": "node .output/server/index.mjs",
     "preview": "vite preview",

--- a/packages/create/src/frameworks/solid/project/base/tsr.config.json
+++ b/packages/create/src/frameworks/solid/project/base/tsr.config.json
@@ -1,0 +1,3 @@
+{
+  "target": "solid"
+}

--- a/packages/create/src/frameworks/solid/project/packages.json
+++ b/packages/create/src/frameworks/solid/project/packages.json
@@ -11,6 +11,9 @@
     }
   },
   "file-router": {
+    "devDependencies": {
+      "@tanstack/router-cli": "^1.133.21"
+    },
     "dependencies": {
       "@tanstack/router-plugin": "^1.133.21"
     }

--- a/packages/create/tests/create-app.test.ts
+++ b/packages/create/tests/create-app.test.ts
@@ -4,8 +4,7 @@ import { resolve } from 'node:path'
 import { createApp } from '../src/create-app.js'
 
 import { createMemoryEnvironment } from '../src/environment.js'
-import { FILE_ROUTER } from '../src/constants.js'
-import { AddOn, Options } from '../src/types.js'
+import type { AddOn, Options } from '../src/types.js'
 
 const simpleOptions = {
   projectName: 'test',
@@ -43,7 +42,7 @@ const simpleOptions = {
   packageManager: 'pnpm',
   typescript: true,
   tailwind: true,
-  mode: FILE_ROUTER,
+  mode: 'file-router',
   variableValues: {},
 } as unknown as Options
 
@@ -86,6 +85,43 @@ describe('createApp', () => {
 
     expect(output.files['/src/test2.txt']).toEqual('Hello-2')
     expect(output.commands.some(({ command }) => command === 'echo')).toBe(true)
+  })
+
+  it.each(['react', 'solid'])(
+    'generates routes for %s file-router apps after install',
+    async (frameworkId) => {
+      const { environment, output } = createMemoryEnvironment()
+      await createApp(environment, {
+        ...simpleOptions,
+        framework: {
+          ...simpleOptions.framework,
+          id: frameworkId,
+        },
+        install: true,
+      } as Options)
+
+      expect(output.commands).toContainEqual({
+        command: 'pnpm',
+        args: ['generate-routes'],
+      })
+    },
+  )
+
+  it('skips route generation when dependency install is skipped', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    await createApp(environment, {
+      ...simpleOptions,
+      framework: {
+        ...simpleOptions.framework,
+        id: 'react',
+      },
+      install: false,
+    })
+
+    expect(output.commands).not.toContainEqual({
+      command: 'pnpm',
+      args: ['generate-routes'],
+    })
   })
 
   it('should create an app - with a add-on', async () => {

--- a/packages/create/tests/framework-template.test.ts
+++ b/packages/create/tests/framework-template.test.ts
@@ -7,9 +7,28 @@ describe('framework templates', () => {
   it.each([
     ['React', createReactFrameworkDefinition],
     ['Solid', createSolidFrameworkDefinition],
-  ])('%s gitignore excludes the generated route tree', (_, createDefinition) => {
+  ])(
+    '%s gitignore does not exclude the generated route tree',
+    (_, createDefinition) => {
+      const framework = createDefinition()
+
+      expect(framework.base._dot_gitignore).not.toContain(
+        'src/routeTree.gen.ts',
+      )
+    },
+  )
+
+  it.each([
+    ['React', createReactFrameworkDefinition],
+    ['Solid', createSolidFrameworkDefinition],
+  ])('%s includes route generation tooling', (_, createDefinition) => {
     const framework = createDefinition()
 
-    expect(framework.base._dot_gitignore).toContain('src/routeTree.gen.ts')
+    expect(framework.base['package.json']).toContain(
+      '"generate-routes": "tsr generate"',
+    )
+    expect(
+      framework.optionalPackages['file-router'].devDependencies,
+    ).toHaveProperty('@tanstack/router-cli')
   })
 })


### PR DESCRIPTION
## What changed

- Stop adding `src/routeTree.gen.ts` to generated React and Solid app gitignores.
- Add `generate-routes` scripts, `@tanstack/router-cli`, and `tsr.config.json` to the file-router scaffolds.
- Run route generation once after dependency install during create so the first TypeScript check has `routeTree.gen.ts` available.
- Update the changeset note to match the corrected behavior.

## Why

`routeTree.gen.ts` is generated, but it is still source input for Router type checking. Ignoring it by default means a fresh checkout can fail `tsc` unless users run dev/build first. The scaffold should track the file and only hide it from editor/lint noise.

## Validation

- `pnpm --filter @tanstack/create build`
- `pnpm --filter @tanstack/create exec tsc --noEmit`
- `pnpm --filter @tanstack/create test`
- Commit hook also ran root build, unit tests, and blocking e2e successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic route generation now runs during app scaffold for React and Solid file-router projects
  * Added `generate-routes` npm script for manual route regeneration in new projects
  * Generated route tree files are now tracked in version control instead of being ignored
<!-- end of auto-generated comment: release notes by coderabbit.ai -->