### PR TITLE
Fix project name prompt placeholder leak

### DIFF
--- a/packages/cli/src/ui-prompts.ts
+++ b/packages/cli/src/ui-prompts.ts
@@ -66,8 +66,7 @@ export async function selectInstall(): Promise<boolean> {
 
 export async function getProjectName(): Promise<string> {
   const value = await text({
-    message: 'What would you like to name your project?',
-    placeholder: 'Leave empty to initialize in the current directory',
+    message: 'Project name (leave empty to use current directory)',
     validate(value) {
       if (isCurrentDirectoryProjectNameInput(value)) {
         return

--- a/packages/cli/tests/ui-prompts.test.ts
+++ b/packages/cli/tests/ui-prompts.test.ts
@@ -34,14 +34,16 @@ describe('getProjectName', () => {
 
     const projectName = await getProjectName()
     const textOptions = textSpy.mock.calls[0]![0] as {
+      message?: string
       placeholder?: string
       validate?: (value: string) => string | undefined
     }
 
     expect(projectName).toBe('')
-    expect(textOptions.placeholder).toBe(
-      'Leave empty to initialize in the current directory',
+    expect(textOptions.message).toBe(
+      'Project name (leave empty to use current directory)',
     )
+    expect(textOptions.placeholder).toBeUndefined()
     expect(textOptions.validate?.('')).toBeUndefined()
     expect(textOptions.validate?.('.')).toBeUndefined()
   })


### PR DESCRIPTION
## Summary

Fixes the interactive project-name prompt so pressing Enter for the current directory no longer lets the placeholder text leak into validation.

## Details

The prompt used Clack's `placeholder` for the current-directory hint. In this edge case, the placeholder could be treated like input after Enter, then validated as a project name and duplicated in the prompt output. The hint now lives in the prompt message, and the project-name prompt no longer sets a placeholder.

## Validation

- `pnpm --filter @tanstack/cli test -- ui-prompts`
- `pnpm --filter @tanstack/cli build`
- Commit hook: `nx run-many --target=build --parallel 5`
- Commit hook: `pnpm test:unit && pnpm test:e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the project name prompt messaging to provide clearer guidance during setup. The prompt now explicitly indicates that you can leave the name field empty to use the current directory as your project location, making this functionality more discoverable and intuitive for new users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->