### PR TITLE
docs(react/powersync): document sync-stream SQL footguns

### DIFF
--- a/packages/create/src/frameworks/react/add-ons/powersync/README.md.ejs
+++ b/packages/create/src/frameworks/react/add-ons/powersync/README.md.ejs
@@ -24,3 +24,14 @@ Set these variables in `.env.local`:
 
 PowerSync setup guidance:
 https://docs.powersync.com/client-sdk-references/js-web
+
+## Sync Stream SQL — Known Footguns
+
+PowerSync evaluates sync-stream SQL server-side in JavaScript and the client runs SQLite. A handful of SQL operators silently disagree across that boundary — bucket keys diverge and rows fail to sync without any error. As of `@powersync/service` versions prior to the fixes listed below, watch out for these in your `sync-rules.yaml`:
+
+- **`JOIN` clauses** are not currently supported in sync streams and silently sync zero rows. Rewrite as a single-table query with a correlated subquery in the `WHERE` clause. See [powersync-ja/powersync-service#662](https://github.com/powersync-ja/powersync-service/pull/662) for a loud error proposal.
+- **`upper()` / `lower()`** apply locale-aware Unicode case folding (length-changing on `ß`, `ﬁ`, Turkish dotted-i) where SQLite is ASCII-only. Avoid as bucket keys over non-ASCII data until [powersync-service#663](https://github.com/powersync-ja/powersync-service/pull/663) lands.
+- **`length()`** returns a UTF-16 code-unit count where SQLite returns code points — diverges 2x on emoji, CJK Extension B-G, ancient scripts. Avoid in bucket-parameter filters until [#664](https://github.com/powersync-ja/powersync-service/pull/664).
+- **`substring()` / `substr()`** indexes by UTF-16 code units and can split surrogate pairs, returning unpaired-surrogate strings. Avoid on user content with non-BMP code points until [#665](https://github.com/powersync-ja/powersync-service/pull/665).
+
+If your starter uses ASCII-only IDs and small integers, you will not hit these. They surface the moment user data includes German `ß`, emoji, CJK Ext-B characters, ligatures, or you reach for `JOIN`. Reference checker: [silentdrop](https://github.com/sravan27/silentdrop).


### PR DESCRIPTION
## What

Adds a "Known Footguns" section to the PowerSync add-on README covering four silent-row-loss bugs in the upstream PowerSync sync-rules engine that affect any starter generated by this add-on, until the upstream fixes ship.

## Why

The PowerSync add-on package.json pins `@powersync/web ^1.26.1`. The sync-stream SQL evaluator in PowerSync up through that version has four operator implementations that disagree with the SQLite that runs on the client — bucket keys silently diverge and rows fail to sync without any error or log line:

1. **JOIN** in sync streams silently syncs zero rows (filter compilation does not track joined tables → silent degenerate filter).
2. **`upper()` / `lower()`** use locale-aware Unicode case folding (length-changing on `ß`, `ﬁ`, Turkish `i`) where SQLite is ASCII-only.
3. **`length()`** returns UTF-16 code-unit count where SQLite returns Unicode code points (2x divergence on emoji, CJK Extension B-G).
4. **`substring()` / `substr()`** slices by UTF-16 code units and can return unpaired-surrogate strings.

The fixes are open upstream:

- https://github.com/powersync-ja/powersync-service/pull/662 (JOIN — surface as loud error)
- https://github.com/powersync-ja/powersync-service/pull/663 (ASCII case folding)
- https://github.com/powersync-ja/powersync-service/pull/664 (`length()` code points)
- https://github.com/powersync-ja/powersync-service/pull/665 (`substring()` code points)

Until they land in `@powersync/service`, this add-on quietly generates starters that will silently lose rows if user data contains any non-ASCII characters or any JOIN gets written into `sync-rules.yaml`. The README addition documents that explicitly with workarounds.

## Maintainer note

Disclosure: I authored the four upstream PRs linked here, plus four already-merged sync-rules fixes in [the same engine](https://github.com/powersync-ja/powersync-service/pulls?q=author%3Asravan27). silentdrop is an open-source MIT correctness checker I built that catches this class of bug across JS DB layers. Happy to remove the silentdrop link if you prefer the section be vendor-neutral.

This is documentation-only — no code change in the generated app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Sync Stream SQL — Known Footguns" section documenting SQL behavior mismatches between server and client, including unsupported JOIN clauses and operator inconsistencies across execution boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->