### PR TITLE
Add changeset for create prompt fix

### DIFF
--- a/.changeset/plain-buses-fix.md
+++ b/.changeset/plain-buses-fix.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/cli": patch
+---
+
+Fix the interactive create prompt so accepting the current directory does not leak placeholder text into project-name validation.


### PR DESCRIPTION
## Summary

Adds the missing changeset for the project-name prompt fix merged in #466.

## Release impact

Marks `@tanstack/cli` for a patch release. Changesets also reports the expected patch bumps for the CLI wrapper packages through internal dependency updates.

## Validation

- `node_modules/.bin/changeset status`
- Commit hook: `nx run-many --target=build --parallel 5`
- Commit hook: `pnpm test:unit && pnpm test:e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the interactive setup prompt where placeholder text would incorrectly appear in the project name field when accepting the current directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->