### PR TITLE
test(create): make path assertions cross-platform

### DIFF
--- a/packages/create/tests/create-app.test.ts
+++ b/packages/create/tests/create-app.test.ts
@@ -4,7 +4,11 @@ import { resolve } from 'node:path'
 import { createApp } from '../src/create-app.js'
 
 import { createMemoryEnvironment } from '../src/environment.js'
-import type { AddOn, Options } from '../src/types.js'
+import type { AddOn, Options, Starter } from '../src/types.js'
+
+function toPosixPath(path: string) {
+  return path.replace(/\\/g, '/').replace(/^[A-Z]:/i, '')
+}
 
 const simpleOptions = {
   projectName: 'test',
@@ -63,9 +67,16 @@ describe('createApp', () => {
 
     const cwd = process.cwd()
 
-    expect(output.files[resolve(cwd, '/foo/bar/baz/src/test.txt')]).toEqual(
-      'Hello',
+    const normalizedFiles = Object.fromEntries(
+      Object.entries(output.files).map(([path, contents]) => [
+        toPosixPath(path),
+        contents,
+      ]),
     )
+
+    expect(
+      normalizedFiles[toPosixPath(resolve(cwd, '/foo/bar/baz/src/test.txt'))],
+    ).toEqual('Hello')
   })
 
   it('should create an app - with a starter', async () => {
@@ -80,7 +91,7 @@ describe('createApp', () => {
         getFiles: () => ['src/test2.txt'],
         getFileContents: () => 'Hello-2',
         getDeletedFiles: () => [],
-      } as unknown as AddOn,
+      } as unknown as Starter,
     })
 
     expect(output.files['/src/test2.txt']).toEqual('Hello-2')

--- a/packages/create/tests/file-helper.test.ts
+++ b/packages/create/tests/file-helper.test.ts
@@ -12,6 +12,10 @@ import {
 vi.mock('node:fs', () => fs)
 vi.mock('node:fs/promises', () => fs.promises)
 
+function toPosixPath(path: string) {
+  return path.replace(/\\/g, '/').replace(/^[A-Z]:/i, '')
+}
+
 beforeEach(() => {
   vol.reset()
 })
@@ -138,7 +142,7 @@ describe('findFilesRecursively', () => {
     const files = {}
     findFilesRecursively('/src', files)
 
-    expect(Object.keys(files)).toEqual([
+    expect(Object.keys(files).map(toPosixPath)).toEqual([
       '/src/subdir/subdir2/test.txt',
       '/src/subdir/test.txt',
       '/src/test.txt',


### PR DESCRIPTION
## Summary

Normalizes path-sensitive create-package test assertions so they pass on Windows as well as POSIX environments.

## Why

A couple of create-package tests expected POSIX-style paths directly. On Windows, the same helpers can return drive-prefixed absolute paths with backslashes during test execution, which caused Windows-only assertion failures.

This keeps the assertions focused on the tested behavior instead of the host platform path format.

## Validation

- pnpm --filter @tanstack/create test
- pnpm --filter @tanstack/cli test
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability with cross-platform path normalization for consistent test execution across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->