### PR TITLE
Fix empty project name prompt crash

### DIFF
--- a/.changeset/project-name-undefined-input.md
+++ b/.changeset/project-name-undefined-input.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/cli": patch
+---
+
+Handle empty interactive project name input without crashing.

--- a/packages/cli/src/ui-prompts.ts
+++ b/packages/cli/src/ui-prompts.ts
@@ -84,7 +84,7 @@ export async function getProjectName(): Promise<string> {
     process.exit(0)
   }
 
-  return value.trim()
+  return value?.trim() ?? ''
 }
 
 export async function selectPackageManager(): Promise<PackageManager> {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -26,8 +26,8 @@ export function getCurrentDirectoryPackageName(): string {
   return getDirectoryPackageName(process.cwd())
 }
 
-export function isCurrentDirectoryProjectNameInput(name: string): boolean {
-  const normalized = name.trim()
+export function isCurrentDirectoryProjectNameInput(name?: string): boolean {
+  const normalized = name?.trim() ?? ''
   return normalized === '' || normalized === '.'
 }
 

--- a/packages/cli/tests/ui-prompts.test.ts
+++ b/packages/cli/tests/ui-prompts.test.ts
@@ -48,6 +48,15 @@ describe('getProjectName', () => {
     expect(textOptions.validate?.('.')).toBeUndefined()
   })
 
+  it('should treat undefined text input as the current directory', async () => {
+    vi.spyOn(clack, 'text').mockImplementation(async () => undefined)
+    vi.spyOn(clack, 'isCancel').mockImplementation(() => false)
+
+    const projectName = await getProjectName()
+
+    expect(projectName).toBe('')
+  })
+
   it('should exit on cancel', async () => {
     vi.spyOn(clack, 'text').mockImplementation(async () => 'Cancelled')
     vi.spyOn(clack, 'isCancel').mockImplementation(() => true)


### PR DESCRIPTION
## Summary
- Treat undefined interactive project name input as an empty current-directory selection.
- Allow the current-directory project-name helper to receive undefined prompt input.
- Add regression coverage for the undefined prompt response.

## Test plan
- pnpm --filter @tanstack/create build
- pnpm --filter @tanstack/cli test -- ui-prompts.test.ts
- pnpm --filter @tanstack/cli build
- Pre-commit ran `pnpm build` and `pnpm test`; visible output showed build, unit tests, and all 3 blocking e2e specs passed, but the Playwright runner hung after reporting the passing specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash that occurred when users left the project name prompt empty during interactive setup. The CLI now properly handles undefined or empty input by gracefully defaulting to the current directory, preventing application failures.

* **Tests**
  * Added test coverage to verify proper handling of empty or skipped project name inputs in interactive mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->