### PR TITLE
Fix Tailwind removal README uninstall command

### DIFF
--- a/packages/create/src/frameworks/react/project/base/README.md.ejs
+++ b/packages/create/src/frameworks/react/project/base/README.md.ejs
@@ -36,7 +36,7 @@ If you prefer not to use Tailwind CSS:
 1. Remove the demo pages in `src/routes/demo/`
 2. Replace the Tailwind import in `src/styles.css` with your own styles
 3. Remove `tailwindcss()` from the plugins array in `vite.config.ts`
-4. Uninstall the packages: `<%= getPackageManagerAddScript('@tailwindcss/vite tailwindcss', true) %>`
+4. Uninstall the packages: `<%= getPackageManagerRemoveScript('@tailwindcss/vite tailwindcss') %>`
 <% if (addOnEnabled.biome || addOnEnabled.eslint) { %>
 ## Linting & Formatting
 <% if (addOnEnabled.biome) { %>

--- a/packages/create/src/frameworks/solid/project/base/README.md.ejs
+++ b/packages/create/src/frameworks/solid/project/base/README.md.ejs
@@ -28,7 +28,7 @@ If you prefer not to use Tailwind CSS:
 1. Remove the demo pages in `src/routes/demo/`
 2. Replace the Tailwind import in `src/styles.css` with your own styles
 3. Remove `tailwindcss()` from the plugins array in `vite.config.ts`
-4. Uninstall the packages: `<%= getPackageManagerAddScript('@tailwindcss/vite tailwindcss', true) %>`
+4. Uninstall the packages: `<%= getPackageManagerRemoveScript('@tailwindcss/vite tailwindcss') %>`
 
 <% for(const addon of addOns.filter(addon => addon.readme)) { %>
 <%- addon.readmeIsEjs ? renderTemplate(addon.readme) : addon.readme %>

--- a/packages/create/src/package-manager.ts
+++ b/packages/create/src/package-manager.ts
@@ -88,6 +88,26 @@ export function getPackageManagerInstallCommand(
   }
 }
 
+export function getPackageManagerUninstallCommand(
+  packagerManager: PackageManager,
+  pkg: string,
+) {
+  switch (packagerManager) {
+    case 'yarn':
+    case 'pnpm':
+    case 'bun':
+      return {
+        command: packagerManager,
+        args: ['remove', pkg],
+      }
+    default:
+      return {
+        command: packagerManager,
+        args: ['uninstall', pkg],
+      }
+  }
+}
+
 export function packageManagerInstall(
   environment: Environment,
   cwd: string,

--- a/packages/create/src/template-file.ts
+++ b/packages/create/src/template-file.ts
@@ -7,6 +7,7 @@ import {
   getPackageManagerExecuteCommand,
   getPackageManagerInstallCommand,
   getPackageManagerScriptCommand,
+  getPackageManagerUninstallCommand,
 } from './package-manager.js'
 import { relativePath } from './file-helpers.js'
 
@@ -58,6 +59,11 @@ export function createTemplateFile(environment: Environment, options: Options) {
         packageName,
         isDev,
       ),
+    )
+  }
+  function getPackageManagerRemoveScript(packageName: string) {
+    return formatCommand(
+      getPackageManagerUninstallCommand(options.packageManager, packageName),
     )
   }
   function getPackageManagerRunScript(
@@ -145,6 +151,7 @@ export function createTemplateFile(environment: Environment, options: Options) {
       routes,
 
       getPackageManagerAddScript,
+      getPackageManagerRemoveScript,
       getPackageManagerRunScript,
       getPackageManagerExecuteScript,
 

--- a/packages/create/tests/package-manager.test.ts
+++ b/packages/create/tests/package-manager.test.ts
@@ -4,6 +4,7 @@ import {
   getPackageManagerExecuteCommand,
   getPackageManagerInstallCommand,
   getPackageManagerScriptCommand,
+  getPackageManagerUninstallCommand,
   translateExecuteCommand,
 } from '../src/package-manager.js'
 import { formatCommand } from '../src/utils.js'
@@ -151,6 +152,34 @@ describe('getPackageManagerInstallCommand', () => {
     expect(
       formatCommand(getPackageManagerInstallCommand('npm', 'vitest', true)),
     ).toBe('npm install vitest -D')
+  })
+})
+
+describe('getPackageManagerUninstallCommand', () => {
+  it('yarn uninstall radix-ui', () => {
+    expect(
+      formatCommand(getPackageManagerUninstallCommand('yarn', 'radix-ui')),
+    ).toBe('yarn remove radix-ui')
+  })
+  it('pnpm uninstall radix-ui', () => {
+    expect(
+      formatCommand(getPackageManagerUninstallCommand('pnpm', 'radix-ui')),
+    ).toBe('pnpm remove radix-ui')
+  })
+  it('bun uninstall radix-ui', () => {
+    expect(
+      formatCommand(getPackageManagerUninstallCommand('bun', 'radix-ui')),
+    ).toBe('bun remove radix-ui')
+  })
+  it('deno uninstall radix-ui', () => {
+    expect(
+      formatCommand(getPackageManagerUninstallCommand('deno', 'radix-ui')),
+    ).toBe('deno uninstall radix-ui')
+  })
+  it('npm uninstall radix-ui', () => {
+    expect(
+      formatCommand(getPackageManagerUninstallCommand('npm', 'radix-ui')),
+    ).toBe('npm uninstall radix-ui')
   })
 })
 

--- a/packages/create/tests/template-file.test.ts
+++ b/packages/create/tests/template-file.test.ts
@@ -166,6 +166,10 @@ describe('createTemplateFile', () => {
       "<%= getPackageManagerAddScript('foo', true) %>",
     )
     await templateFile(
+      'remove-foo.txt.ejs',
+      "<%= getPackageManagerRemoveScript('foo') %>",
+    )
+    await templateFile(
       'run-dev.txt.ejs',
       "<%= getPackageManagerRunScript('dev') %>",
     )
@@ -173,6 +177,7 @@ describe('createTemplateFile', () => {
 
     expect(output.files['/test/foo.txt']).toEqual('pnpm add foo')
     expect(output.files['/test/foo-dev.txt']).toEqual('pnpm add foo --dev')
+    expect(output.files['/test/remove-foo.txt']).toEqual('pnpm remove foo')
     expect(output.files['/test/run-dev.txt']).toEqual('pnpm dev')
   })
 


### PR DESCRIPTION
Fixes the generated React and Solid template READMEs so the “removing Tailwind” instructions use package-manager specific uninstall commands instead of install commands.

Changes:
- Added getPackageManagerUninstallCommand
- Added the EJS helper getPackageManagerRemoveScript
- Updated React and Solid base README templates to use the remove helper
- Added tests for uninstall command formatting and template helper rendering

For example with npm:

Previously:
```
### Removing Tailwind CSS

If you prefer not to use Tailwind CSS:

1. Remove the demo pages in `src/routes/demo/`
2. Replace the Tailwind import in `src/styles.css` with your own styles
3. Remove `tailwindcss()` from the plugins array in `vite.config.ts`
4. Uninstall the packages: `npm install @tailwindcss/vite tailwindcss -D`
                                ^^^^^^^
```

With this change:
```
### Removing Tailwind CSS

If you prefer not to use Tailwind CSS:

1. Remove the demo pages in `src/routes/demo/`
2. Replace the Tailwind import in `src/styles.css` with your own styles
3. Remove `tailwindcss()` from the plugins array in `vite.config.ts`
4. Uninstall the packages: `npm uninstall @tailwindcss/vite tailwindcss')`
                                ^^^^^^^^^
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected Tailwind CSS removal instructions in generated React and Solid project README templates to use proper package manager-specific uninstall commands.

* **Tests**
  * Added test coverage for package manager uninstall functionality and template file generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->