### PR TITLE
chore: update pnpm to 11.9.0

### DIFF
--- a/cli-aliases/create-start-app/package.json
+++ b/cli-aliases/create-start-app/package.json
@@ -28,7 +28,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/cli-aliases/create-tanstack-app/package.json
+++ b/cli-aliases/create-tanstack-app/package.json
@@ -28,7 +28,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/cli-aliases/create-tanstack/package.json
+++ b/cli-aliases/create-tanstack/package.json
@@ -28,7 +28,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/cli-aliases/create-tsrouter-app/package.json
+++ b/cli-aliases/create-tsrouter-app/package.json
@@ -28,7 +28,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/cli-aliases/ts-create-start/package.json
+++ b/cli-aliases/ts-create-start/package.json
@@ -28,7 +28,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/examples/custom-cli/create-qwik-app/package.json
+++ b/examples/custom-cli/create-qwik-app/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/examples/custom-cli/create-rwsdk/package.json
+++ b/examples/custom-cli/create-rwsdk/package.json
@@ -25,7 +25,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/examples/custom-cli/customized-react/package.json
+++ b/examples/custom-cli/customized-react/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@tanstack/cli": "workspace:*",
     "@tanstack/create": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/cli.git"
   },
-  "packageManager": "pnpm@11.1.0",
+  "packageManager": "pnpm@11.9.0",
   "type": "module",
   "scripts": {
     "cleanNodeModules": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=20"
   },

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -65,7 +65,7 @@
   ],
   "author": "Jack Herrington <jherr@pobox.com>",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=20"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 cleanupUnusedCatalogs: true
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 cleanupUnusedCatalogs: true
+minimumReleaseAge: 1
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 


### PR DESCRIPTION
## Summary
- update pnpm packageManager pins to 11.9.0
- add pnpm minimumReleaseAge: 1 to the workspace config
- refresh/verify the lockfile with pnpm 11.9.0

## Verification
- pnpm install --lockfile-only --ignore-scripts
- pnpm install --frozen-lockfile --ignore-scripts --trust-lockfile=false
- git diff --check

## Trust policy
- no trustPolicy violations reported; no trustPolicyExclude entries added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and related templates to use a newer package manager version.
  * Added a minimum release age for workspace package selection, helping avoid very recent package releases during installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->