### PR TITLE
fix(create): use shared router factory in router-only apps

### DIFF
--- a/packages/create/src/frameworks/react/project/base/src/main.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/main.tsx.ejs
@@ -1,19 +1,9 @@
 <% if (!routerOnly) { ignoreFile() } %>
 import ReactDOM from 'react-dom/client'
-import { RouterProvider, createRouter } from '@tanstack/react-router'
-import { routeTree } from './routeTree.gen'
+import { RouterProvider } from '@tanstack/react-router'
+import { getRouter } from './router'
 
-const router = createRouter({
-  routeTree,
-  defaultPreload: 'intent',
-  scrollRestoration: true,
-})
-
-declare module '@tanstack/react-router' {
-  interface Register {
-    router: typeof router
-  }
-}
+const router = getRouter()
 
 const rootElement = document.getElementById('app')!
 

--- a/packages/create/src/frameworks/solid/project/base/src/main.tsx.ejs
+++ b/packages/create/src/frameworks/solid/project/base/src/main.tsx.ejs
@@ -1,20 +1,9 @@
 <% if (!routerOnly) { ignoreFile() } %>
 import { render } from 'solid-js/web'
-import { RouterProvider, createRouter } from '@tanstack/solid-router'
-import { routeTree } from './routeTree.gen'
+import { RouterProvider } from '@tanstack/solid-router'
+import { getRouter } from './router'
 
-const router = createRouter({
-  routeTree,
-  defaultPreload: 'intent',
-  defaultPreloadStaleTime: 0,
-  scrollRestoration: true,
-})
-
-declare module '@tanstack/solid-router' {
-  interface Register {
-    router: typeof router
-  }
-}
+const router = getRouter()
 
 const rootElement = document.getElementById('app')!
 

--- a/packages/create/tests/framework-template.test.ts
+++ b/packages/create/tests/framework-template.test.ts
@@ -89,6 +89,9 @@ describe('framework templates', () => {
       const { main, router } = await renderRouterOnlyEntries(createDefinition())
 
       expect(main).toContain(getRouterImport)
+      expect(main).toContain(
+        `import { RouterProvider } from '${routerPackage}'`,
+      )
       expect(main).toContain('const router = getRouter()')
       expect(main).toContain(`<RouterProvider router={router} />`)
       expect(main).not.toContain('createRouter')

--- a/packages/create/tests/framework-template.test.ts
+++ b/packages/create/tests/framework-template.test.ts
@@ -1,7 +1,45 @@
 import { describe, expect, it } from 'vitest'
 
+import { createMemoryEnvironment } from '../src/environment.js'
 import { createFrameworkDefinition as createReactFrameworkDefinition } from '../src/frameworks/react/index.js'
 import { createFrameworkDefinition as createSolidFrameworkDefinition } from '../src/frameworks/solid/index.js'
+import { createTemplateFile } from '../src/template-file.js'
+
+import type { FrameworkDefinition, Options } from '../src/types.js'
+
+const routerOnlyTemplateOptions = {
+  projectName: 'test',
+  targetDir: '/test',
+  framework: {
+    id: 'test',
+    name: 'Test',
+  },
+  chosenAddOns: [],
+  addOnOptions: {},
+  packageManager: 'pnpm',
+  typescript: true,
+  tailwind: true,
+  mode: 'file-router',
+  routerOnly: true,
+} as unknown as Options
+
+async function renderRouterOnlyEntries(framework: FrameworkDefinition) {
+  const { environment, output } = createMemoryEnvironment()
+  const templateFile = createTemplateFile(
+    environment,
+    routerOnlyTemplateOptions,
+  )
+
+  environment.startRun()
+  await templateFile('src/main.tsx.ejs', framework.base['src/main.tsx.ejs'])
+  await templateFile('src/router.tsx.ejs', framework.base['src/router.tsx.ejs'])
+  environment.finishRun()
+
+  return {
+    main: output.files['/test/src/main.tsx'],
+    router: output.files['/test/src/router.tsx'],
+  }
+}
 
 describe('framework templates', () => {
   it.each([
@@ -31,4 +69,33 @@ describe('framework templates', () => {
       framework.optionalPackages['file-router'].devDependencies,
     ).toHaveProperty('@tanstack/router-cli')
   })
+
+  it.each([
+    [
+      'React',
+      createReactFrameworkDefinition,
+      '@tanstack/react-router',
+      "import { getRouter } from './router'",
+    ],
+    [
+      'Solid',
+      createSolidFrameworkDefinition,
+      '@tanstack/solid-router',
+      "import { getRouter } from './router'",
+    ],
+  ])(
+    '%s router-only main uses the shared router factory',
+    async (_, createDefinition, routerPackage, getRouterImport) => {
+      const { main, router } = await renderRouterOnlyEntries(createDefinition())
+
+      expect(main).toContain(getRouterImport)
+      expect(main).toContain('const router = getRouter()')
+      expect(main).toContain(`<RouterProvider router={router} />`)
+      expect(main).not.toContain('createRouter')
+      expect(main).not.toContain(`declare module '${routerPackage}'`)
+      expect(router).toContain('export function getRouter()')
+      expect(router).toContain(`declare module '${routerPackage}'`)
+      expect(router).toContain('router: ReturnType<typeof getRouter>')
+    },
+  )
 })


### PR DESCRIPTION
## Summary

Fixes router-only scaffolds so the generated SPA entrypoint uses the shared router factory from `src/router.tsx`.

Before this change, `create --router-only` generated:

- `src/router.tsx` with `getRouter()` and a `Register` module augmentation
- `src/main.tsx` with a separate inline `createRouter(...)` call and another `Register` module augmentation

That left `router.tsx` effectively unused in router-only projects and duplicated the router registration.

This updates both React and Solid router-only `main.tsx` templates to import `getRouter()` from `./router` and pass that router to `RouterProvider`.

## Changes

- React router-only `main.tsx` now uses `getRouter()`
- Solid router-only `main.tsx` now uses `getRouter()`
- The `Register` declaration remains centralized in `router.tsx`

## Testing

- `CI=true pnpm --filter @tanstack/create test -- framework-template.test.ts`
- `git diff --check`

Close #480 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * React and Solid app templates now use a shared router initialization helper to simplify bootstrapping.
  * Generated apps still mount the router only when the root element is empty.

* **Bug Fixes**
  * Improved template consistency for router-based projects across both frameworks.

* **Tests**
  * Expanded coverage with router-only rendering checks for both React and Solid templates, including expected imports and type declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->