### PR TITLE
fix(create): repair router-only package manifests

### DIFF
--- a/.changeset/tidy-spoons-dream.md
+++ b/.changeset/tidy-spoons-dream.md
@@ -1,0 +1,6 @@
+---
+"@tanstack/create": patch
+"@tanstack/cli": patch
+---
+
+Fix router-only package manifests by providing `@tanstack/router-core` for devtools under strict package managers and keeping `@tanstack/router-plugin` in devDependencies only.

--- a/packages/create/src/frameworks/react/project/packages.json
+++ b/packages/create/src/frameworks/react/project/packages.json
@@ -16,9 +16,7 @@
   },
   "file-router": {
     "devDependencies": {
-      "@tanstack/router-cli": "^1.132.0"
-    },
-    "dependencies": {
+      "@tanstack/router-cli": "^1.132.0",
       "@tanstack/router-plugin": "^1.132.0"
     }
   }

--- a/packages/create/src/frameworks/solid/project/packages.json
+++ b/packages/create/src/frameworks/solid/project/packages.json
@@ -12,9 +12,7 @@
   },
   "file-router": {
     "devDependencies": {
-      "@tanstack/router-cli": "^1.133.21"
-    },
-    "dependencies": {
+      "@tanstack/router-cli": "^1.133.21",
       "@tanstack/router-plugin": "^1.133.21"
     }
   }

--- a/packages/create/src/package-json.ts
+++ b/packages/create/src/package-json.ts
@@ -66,6 +66,25 @@ export function createPackageJSON(options: Options) {
     return formatCommand(getPackageManagerExecuteCommand(packageManager, pkg, args))
   }
 
+  function applyRouterOnlyPackageJSONCompat() {
+    const routerPluginVersion =
+      packageJSON.devDependencies?.['@tanstack/router-plugin'] ??
+      packageJSON.dependencies?.['@tanstack/router-plugin'] ??
+      'latest'
+
+    delete packageJSON.dependencies?.['@tanstack/router-plugin']
+
+    packageJSON.devDependencies = {
+      ...(packageJSON.devDependencies ?? {}),
+      '@tanstack/router-plugin': routerPluginVersion,
+    }
+    packageJSON.dependencies = {
+      ...(packageJSON.dependencies ?? {}),
+      '@tanstack/router-core':
+        packageJSON.dependencies?.['@tanstack/router-core'] ?? 'latest',
+    }
+  }
+
   let packageJSON = {
     ...JSON.parse(JSON.stringify(options.framework.basePackageJSON)),
     name: options.projectName,
@@ -133,22 +152,14 @@ export function createPackageJSON(options: Options) {
     if (options.framework.id === 'react') {
       delete packageJSON.dependencies?.['@tanstack/react-start']
       delete packageJSON.dependencies?.['@tanstack/react-router-ssr-query']
-      packageJSON.devDependencies = {
-        ...(packageJSON.devDependencies ?? {}),
-        '@tanstack/router-plugin':
-          packageJSON.devDependencies?.['@tanstack/router-plugin'] ?? 'latest',
-      }
+      applyRouterOnlyPackageJSONCompat()
     }
 
     if (options.framework.id === 'solid') {
       delete packageJSON.dependencies?.['@tanstack/solid-start']
       delete packageJSON.dependencies?.['@tanstack/solid-router-ssr-query']
       delete packageJSON.scripts?.start
-      packageJSON.devDependencies = {
-        ...(packageJSON.devDependencies ?? {}),
-        '@tanstack/router-plugin':
-          packageJSON.devDependencies?.['@tanstack/router-plugin'] ?? 'latest',
-      }
+      applyRouterOnlyPackageJSONCompat()
     }
   }
 

--- a/packages/create/tests/package-json.test.ts
+++ b/packages/create/tests/package-json.test.ts
@@ -60,6 +60,100 @@ describe('createPackageJSON', () => {
     expect(JSON.stringify(packageJSON)).toEqual(JSON.stringify(expected))
   })
 
+  it('should create a strict package-manager compatible React router-only package.json', () => {
+    const packageJSON = createPackageJSON({
+      chosenAddOns: [],
+      mode: 'file-router',
+      routerOnly: true,
+      typescript: true,
+      tailwind: true,
+      projectName: 'test',
+      framework: {
+        id: 'react',
+        basePackageJSON: {
+          dependencies: {
+            '@tanstack/react-router': 'latest',
+            '@tanstack/react-router-devtools': 'latest',
+            '@tanstack/react-router-ssr-query': 'latest',
+            '@tanstack/react-start': 'latest',
+          },
+          devDependencies: {},
+        },
+        optionalPackages: {
+          typescript: {},
+          tailwindcss: {},
+          'file-router': {
+            dependencies: {
+              '@tanstack/router-plugin': '^1.132.0',
+            },
+            devDependencies: {
+              '@tanstack/router-cli': '^1.132.0',
+            },
+          },
+        },
+      } as unknown as Framework,
+    } as unknown as Options)
+
+    expect(packageJSON.dependencies).toEqual({
+      '@tanstack/react-router': 'latest',
+      '@tanstack/react-router-devtools': 'latest',
+      '@tanstack/router-core': 'latest',
+    })
+    expect(packageJSON.devDependencies).toEqual({
+      '@tanstack/router-cli': '^1.132.0',
+      '@tanstack/router-plugin': '^1.132.0',
+    })
+  })
+
+  it('should move router-plugin to devDependencies for Solid router-only package.json', () => {
+    const packageJSON = createPackageJSON({
+      chosenAddOns: [],
+      mode: 'file-router',
+      routerOnly: true,
+      typescript: true,
+      tailwind: true,
+      projectName: 'test',
+      framework: {
+        id: 'solid',
+        basePackageJSON: {
+          scripts: {
+            start: 'node .output/server/index.mjs',
+          },
+          dependencies: {
+            '@tanstack/solid-router': 'latest',
+            '@tanstack/solid-router-devtools': 'latest',
+            '@tanstack/solid-router-ssr-query': 'latest',
+            '@tanstack/solid-start': 'latest',
+          },
+          devDependencies: {},
+        },
+        optionalPackages: {
+          typescript: {},
+          tailwindcss: {},
+          'file-router': {
+            dependencies: {
+              '@tanstack/router-plugin': '^1.133.21',
+            },
+            devDependencies: {
+              '@tanstack/router-cli': '^1.133.21',
+            },
+          },
+        },
+      } as unknown as Framework,
+    } as unknown as Options)
+
+    expect(packageJSON.dependencies).toEqual({
+      '@tanstack/router-core': 'latest',
+      '@tanstack/solid-router': 'latest',
+      '@tanstack/solid-router-devtools': 'latest',
+    })
+    expect(packageJSON.devDependencies).toEqual({
+      '@tanstack/router-cli': '^1.133.21',
+      '@tanstack/router-plugin': '^1.133.21',
+    })
+    expect(packageJSON.scripts).toEqual({})
+  })
+
   it('should include sqlite build approval for pnpm templates', () => {
     const packageJSON = createPackageJSON({
       chosenAddOns: [


### PR DESCRIPTION
## Summary

- Add `@tanstack/router-core` to router-only React and Solid app dependencies so generated devtools resolve under strict package managers like Yarn PnP.
- Keep `@tanstack/router-plugin` in `devDependencies` only for file-router templates, avoiding duplicate dependency/devDependency entries.
- Preserve the existing router plugin version when router-only compatibility code moves it between package sections.

## Reproduction

Reproduction repo: https://github.com/jingjing2222/tanstack-router-pnp-peer-repro

The repo contains two workspaces:

- `apps/repro`: generated with `yarn dlx @tanstack/cli create --router-only ...`
- `apps/fixed`: same app with only package manifest fixes applied

`yarn dev:repro` fails during Vite dependency optimization because `@tanstack/router-devtools-core` imports `@tanstack/router-core`, but the generated app does not provide it directly.

Failure screenshot: https://github.com/jingjing2222/tanstack-router-pnp-peer-repro/blob/main/docs/assets/repro-fails.png

`yarn dev:fixed` starts successfully after adding `@tanstack/router-core` and removing the duplicate `@tanstack/router-plugin` dependency entry.

Success screenshot: https://github.com/jingjing2222/tanstack-router-pnp-peer-repro/blob/main/docs/assets/fixed-starts.png


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router-only project setup for strict package managers to ensure routing packages land in the correct dependency sections (with the router plugin in development dependencies and router core where required).
  * Fixed React and Solid template package files to produce cleaner JSON output.
* **Tests**
  * Added unit tests covering router-only dependency behavior for React and Solid templates.
* **Chores**
  * Updated `@tanstack/create` and `@tanstack/cli` to patch-level releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->