### PR TITLE
fix: add pnpm build approvals for `sharp` and `workerd` in Cloudflare deployment add-on

### DIFF
--- a/packages/create/src/frameworks/react/hosts/cloudflare/package.json.ejs
+++ b/packages/create/src/frameworks/react/hosts/cloudflare/package.json.ejs
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "wrangler": "^4.70.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["sharp", "workerd"]
   }
 }

--- a/packages/create/src/frameworks/solid/hosts/cloudflare/package.json.ejs
+++ b/packages/create/src/frameworks/solid/hosts/cloudflare/package.json.ejs
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "wrangler": "^4.70.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["sharp", "workerd"]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/TanStack/cli/issues/484

When using pnpm v11, creating a Cloudflare-deployed project fails because `wrangler` transitively depends on `sharp` and `workerd`, which have build scripts that are not listed in `pnpm.onlyBuiltDependencies`.

Add these entries to both the React and Solid Cloudflare host `package.json.ejs` templates so they are merged with the base approvals at project creation time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloudflare React and Solid project templates to limit dependency build steps during installation.
  * Improved installation consistency and security by allowing build scripts only for required packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->