### PR TITLE
fix: harden Prisma and Netlify scaffolds

### DIFF
--- a/.changeset/honest-partner-paths.md
+++ b/.changeset/honest-partner-paths.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/create': patch
+---
+
+Fix pnpm 11 build approvals for Prisma and Netlify projects, make generated Prisma MySQL apps use their configured `DATABASE_URL`, and update the Prisma demo to current server-function and package-script APIs.

--- a/packages/create/src/frameworks/react/add-ons/prisma/assets/prisma/seed.ts.ejs
+++ b/packages/create/src/frameworks/react/add-ons/prisma/assets/prisma/seed.ts.ejs
@@ -1,19 +1,18 @@
 import { PrismaClient } from "../src/generated/prisma/client.js";
+<% if (addOnOption.prisma.database !== 'sqlite') { %>
+import { getDatabaseUrl } from '../src/database-url.js'
+<% } %>
 
 <% if (addOnOption.prisma.database === 'postgres') { %>
 import { PrismaPg } from '@prisma/adapter-pg';
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
+  connectionString: getDatabaseUrl(),
 });<% } %>
 
 <% if (addOnOption.prisma.database === 'mysql') { %>
 import { PrismaMariaDb } from '@prisma/adapter-mariadb';
-const adapter = new PrismaMariaDb({
-  host: "localhost",
-  port: 3306,
-  connectionLimit: 5
-});<% } %>
+const adapter = new PrismaMariaDb(getDatabaseUrl());<% } %>
 
 <% if (addOnOption.prisma.database === 'sqlite') { %>
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';

--- a/packages/create/src/frameworks/react/add-ons/prisma/assets/src/database-url.ts.ejs
+++ b/packages/create/src/frameworks/react/add-ons/prisma/assets/src/database-url.ts.ejs
@@ -1,0 +1,10 @@
+<% if (addOnOption.prisma.database === 'sqlite') { ignoreFile(); return; } -%>
+export function getDatabaseUrl() {
+  const databaseUrl = process.env.DATABASE_URL
+
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required')
+  }
+
+  return databaseUrl
+}

--- a/packages/create/src/frameworks/react/add-ons/prisma/assets/src/db.ts.ejs
+++ b/packages/create/src/frameworks/react/add-ons/prisma/assets/src/db.ts.ejs
@@ -1,19 +1,18 @@
 import { PrismaClient } from './generated/prisma/client.js'
+<% if (addOnOption.prisma.database !== 'sqlite') { %>
+import { getDatabaseUrl } from './database-url.js'
+<% } %>
 
 <% if (addOnOption.prisma.database === 'postgres') { %>
 import { PrismaPg } from '@prisma/adapter-pg';
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
+  connectionString: getDatabaseUrl(),
 });<% } %>
 
 <% if (addOnOption.prisma.database === 'mysql') { %>
 import { PrismaMariaDb } from '@prisma/adapter-mariadb';
-const adapter = new PrismaMariaDb({
-  host: "localhost",
-  port: 3306,
-  connectionLimit: 5
-});<% } %>
+const adapter = new PrismaMariaDb(getDatabaseUrl());<% } %>
 
 <% if (addOnOption.prisma.database === 'sqlite') { %>
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';

--- a/packages/create/src/frameworks/react/add-ons/prisma/assets/src/routes/demo/prisma.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/prisma/assets/src/routes/demo/prisma.tsx.ejs
@@ -13,7 +13,7 @@ const getTodos = createServerFn({
 const createTodo = createServerFn({
   method: 'POST',
 })
-  .inputValidator((data: { title: string }) => data)
+  .validator((data: { title: string }) => data)
   .handler(async ({ data }) => {
     return await prisma.todo.create({
       data,
@@ -31,15 +31,15 @@ function DemoPrisma() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    const formData = new FormData(e.target as HTMLFormElement)
-    const title = formData.get('title') as string
+    const form = e.currentTarget
+    const title = new FormData(form).get('title')
 
-    if (!title) return
+    if (typeof title !== 'string' || !title) return
 
     try {
       await createTodo({ data: { title } })
       router.invalidate()
-      ;(e.target as HTMLFormElement).reset()
+      form.reset()
     } catch (error) {
       console.error('Failed to create todo:', error)
     }
@@ -99,7 +99,7 @@ function DemoPrisma() {
             Powered by Prisma ORM
           </h3>
           <p className="demo-muted mb-4 text-sm">
-            Next-generation ORM for Node.js & TypeScript with PostgreSQL
+            Next-generation ORM for Node.js & TypeScript with <%= addOnOption.prisma.database === 'postgres' ? 'PostgreSQL' : addOnOption.prisma.database === 'mysql' ? 'MySQL' : 'SQLite' %>
           </p>
           <div className="space-y-2 text-sm">
             <p className="font-medium">Setup Instructions:</p>
@@ -112,19 +112,19 @@ function DemoPrisma() {
               <li>
                 Run:{' '}
                 <code>
-                  <%- getPackageManagerExecuteScript('prisma', ['generate']) %>
+                  <%- getPackageManagerRunScript('db:generate') %>
                 </code>
               </li>
               <li>
                 Run:{' '}
                 <code>
-                  <%- getPackageManagerExecuteScript('prisma', ['db', 'push']) %>
+                  <%- getPackageManagerRunScript('db:push') %>
                 </code>
               </li>
               <li>
                 Optional:{' '}
                 <code>
-                  <%- getPackageManagerExecuteScript('prisma', ['studio']) %>
+                  <%- getPackageManagerRunScript('db:studio') %>
                 </code>
               </li>
             </ol>

--- a/packages/create/src/frameworks/react/add-ons/prisma/package.json.ejs
+++ b/packages/create/src/frameworks/react/add-ons/prisma/package.json.ejs
@@ -17,9 +17,12 @@
     "db:migrate": "dotenv -e .env.local -- prisma migrate dev",
     "db:studio": "dotenv -e .env.local -- prisma studio",
     "db:seed": "dotenv -e .env.local -- prisma db seed"
-  }<% if (addOnOption.prisma.database === 'sqlite') { %>,
+  },
   "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3"]
+    "onlyBuiltDependencies": [
+      "@prisma/engines",
+      "prisma"<% if (addOnOption.prisma.database === 'sqlite') { %>,
+      "better-sqlite3"<% } %>
+    ]
   }
-  <% } %>
 }

--- a/packages/create/src/frameworks/react/hosts/netlify/package.json
+++ b/packages/create/src/frameworks/react/hosts/netlify/package.json
@@ -1,5 +1,10 @@
 {
   "devDependencies": {
     "@netlify/vite-plugin-tanstack-start": "^1.2.15"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
   }
 }

--- a/packages/create/src/frameworks/react/project/base/pnpm-workspace.yaml.ejs
+++ b/packages/create/src/frameworks/react/project/base/pnpm-workspace.yaml.ejs
@@ -5,10 +5,16 @@ allowBuilds:
 <% if (addOnEnabled.sentry) { -%>
   '@sentry/cli': true
 <% } -%>
-<% if (addOnEnabled.cloudflare) { -%>
+<% if (addOnEnabled.cloudflare || addOnEnabled.netlify) { -%>
   sharp: true
+<% } -%>
+<% if (addOnEnabled.cloudflare) { -%>
   workerd: true
 <% } -%>
-<% if (addOnEnabled.drizzle || addOnEnabled.prisma) { -%>
+<% if (addOnEnabled.prisma) { -%>
+  '@prisma/engines': true
+  prisma: true
+<% } -%>
+<% if (addOnEnabled.drizzle || (addOnEnabled.prisma && addOnOption.prisma.database === 'sqlite')) { -%>
   better-sqlite3: true
 <% } -%>

--- a/packages/create/src/frameworks/solid/hosts/netlify/package.json
+++ b/packages/create/src/frameworks/solid/hosts/netlify/package.json
@@ -1,5 +1,10 @@
 {
   "devDependencies": {
     "@netlify/vite-plugin-tanstack-start": "^1.2.15"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
   }
 }

--- a/packages/create/src/frameworks/solid/project/base/pnpm-workspace.yaml.ejs
+++ b/packages/create/src/frameworks/solid/project/base/pnpm-workspace.yaml.ejs
@@ -2,7 +2,9 @@
 allowBuilds:
   esbuild: true
   lightningcss: true
-<% if (addOnEnabled.cloudflare) { -%>
+<% if (addOnEnabled.cloudflare || addOnEnabled.netlify) { -%>
   sharp: true
+<% } -%>
+<% if (addOnEnabled.cloudflare) { -%>
   workerd: true
 <% } -%>

--- a/packages/create/tests/partner-addons.test.ts
+++ b/packages/create/tests/partner-addons.test.ts
@@ -23,9 +23,11 @@ function frameworkFromDefinition(definition: FrameworkDefinition): Framework {
 async function generateApp(
   definition: FrameworkDefinition,
   addOnIds: Array<string>,
+  addOnOptions: Options['addOnOptions'] = {},
 ) {
   const framework = frameworkFromDefinition(definition)
   const chosenAddOns = await finalizeAddOns(framework, 'file-router', addOnIds)
+  const defaultAddOnOptions = populateAddOnOptionsDefaults(chosenAddOns)
   const targetDir = '/partner-app'
   const { environment, output } = createMemoryEnvironment(targetDir)
 
@@ -41,7 +43,10 @@ async function generateApp(
     install: false,
     intent: false,
     chosenAddOns,
-    addOnOptions: populateAddOnOptionsDefaults(chosenAddOns),
+    addOnOptions: {
+      ...defaultAddOnOptions,
+      ...addOnOptions,
+    },
     includeExamples: true,
   } satisfies Options)
 
@@ -175,6 +180,78 @@ describe('partner add-on scaffolds', () => {
       expect(readme).not.toContain('dist/client')
     },
   )
+
+  it.each([
+    ['React', createReactFrameworkDefinition],
+    ['Solid', createSolidFrameworkDefinition],
+  ])(
+    'approves Netlify build dependencies for pnpm in %s projects',
+    async (_name, createFrameworkDefinition) => {
+      const output = await generateApp(createFrameworkDefinition(), ['netlify'])
+      const packageJSON = JSON.parse(output.files['package.json'])
+      const pnpmWorkspace = output.files['pnpm-workspace.yaml']
+
+      expect(packageJSON.pnpm.onlyBuiltDependencies).toContain('sharp')
+      expect(pnpmWorkspace).toContain('sharp: true')
+      expect(pnpmWorkspace).not.toContain('workerd: true')
+    },
+  )
+
+  it.each(['postgres', 'mysql', 'sqlite'])(
+    'approves Prisma build dependencies for pnpm with %s',
+    async (database) => {
+      const output = await generateApp(
+        createReactFrameworkDefinition(),
+        ['prisma'],
+        { prisma: { database } },
+      )
+      const packageJSON = JSON.parse(output.files['package.json'])
+      const pnpmWorkspace = output.files['pnpm-workspace.yaml']
+
+      expect(packageJSON.pnpm.onlyBuiltDependencies).toEqual(
+        expect.arrayContaining(['@prisma/engines', 'prisma']),
+      )
+      expect(pnpmWorkspace).toContain("'@prisma/engines': true")
+      expect(pnpmWorkspace).toContain('prisma: true')
+
+      if (database === 'sqlite') {
+        expect(packageJSON.pnpm.onlyBuiltDependencies).toContain(
+          'better-sqlite3',
+        )
+        expect(pnpmWorkspace).toContain('better-sqlite3: true')
+      } else {
+        expect(packageJSON.pnpm.onlyBuiltDependencies).not.toContain(
+          'better-sqlite3',
+        )
+        expect(pnpmWorkspace).not.toContain('better-sqlite3: true')
+      }
+    },
+  )
+
+  it('generates a URL-driven, env-aware Prisma MySQL setup', async () => {
+    const output = await generateApp(
+      createReactFrameworkDefinition(),
+      ['prisma'],
+      { prisma: { database: 'mysql' } },
+    )
+    const databaseUrl = output.files['src/database-url.ts']
+    const db = output.files['src/db.ts']
+    const seed = output.files['prisma/seed.ts']
+    const demo = output.files['src/routes/demo/prisma.tsx']
+
+    expect(databaseUrl).toContain('process.env.DATABASE_URL')
+    expect(databaseUrl).toContain("throw new Error('DATABASE_URL is required')")
+    expect(db).toContain('new PrismaMariaDb(getDatabaseUrl())')
+    expect(seed).toContain('new PrismaMariaDb(getDatabaseUrl())')
+    expect(db).not.toContain('host: "localhost"')
+    expect(seed).not.toContain('host: "localhost"')
+    expect(demo).toContain('.validator(')
+    expect(demo).not.toContain('.inputValidator(')
+    expect(demo).toContain('pnpm db:generate')
+    expect(demo).toContain('pnpm db:push')
+    expect(demo).toContain('pnpm db:studio')
+    expect(demo).not.toContain('pnpm dlx prisma')
+  })
 
   it.each([
     ['React', createReactFrameworkDefinition],


### PR DESCRIPTION
## Summary

- approve Prisma and Netlify native build dependencies for pnpm 10 and 11
- make generated Prisma MySQL runtime and seed code honor `DATABASE_URL`
- update the Prisma demo to current server-function and package-script APIs
- add focused generator coverage and a patch changeset for `@tanstack/create`

## Validation

- full monorepo build
- 101 CLI tests and 248 Create tests
- 7 blocking end-to-end tests
- fresh Prisma MySQL and React/Solid Netlify scaffold builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prisma-generated applications now consistently use the configured `DATABASE_URL` for MySQL and PostgreSQL.
  * Improved Prisma todo demo form handling, validation, reset behavior, and database-specific messaging.
  * Updated generated Prisma setup instructions to use the appropriate package-manager commands.

* **Improvements**
  * Improved dependency build configuration for Prisma, SQLite, Netlify, and Cloudflare projects.
  * Generated projects now include only the dependencies required by the selected database and hosting options.

* **Tests**
  * Added coverage for partner add-ons, database variants, environment-based configuration, and generated project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->