### PR TITLE
fix(create): report Intent as skipped when --no-install is used

### DIFF
--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -4,6 +4,8 @@ import { isBase64, isDemoFilePath } from './file-helpers.js'
 import { formatCommand } from './utils.js'
 import { writeConfigFileToEnvironment } from './config-file.js'
 import {
+  getPackageManagerExecuteCommand,
+  getPackageManagerInstallCommand,
   getPackageManagerScriptCommand,
   packageManagerInstall,
   translateExecuteCommand,
@@ -413,9 +415,24 @@ function buildNextSteps(options: Options): string {
     sections.push(`Docs for the integrations you picked:\n${docLines.join('\n')}`)
   }
   if (options.intent) {
-    sections.push(
-      `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nwith explicit skill mappings for the libraries you installed. Try asking your agent:\n  • "migrate this Next.js page to TanStack Start"\n  • "add a protected /dashboard route"\n  • "show me how to use TanStack Router search params"`,
-    )
+    if (options.install === false) {
+      const installCommand = formatCommand(
+        getPackageManagerInstallCommand(options.packageManager),
+      )
+      const intentCommand = formatCommand(
+        getPackageManagerExecuteCommand(options.packageManager, '@tanstack/intent', [
+          'install',
+          '--map',
+        ]),
+      )
+      sections.push(
+        `Working with an AI agent? TanStack Intent was skipped because dependency installation was\nskipped, so no agent config (AGENTS.md / CLAUDE.md) was written. After installing dependencies,\nwire it up with:\n  % ${installCommand}\n  % ${intentCommand}`,
+      )
+    } else {
+      sections.push(
+        `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nwith explicit skill mappings for the libraries you installed. Try asking your agent:\n  • "migrate this Next.js page to TanStack Start"\n  • "add a protected /dashboard route"\n  • "show me how to use TanStack Router search params"`,
+      )
+    }
   }
 
   return sections.length > 0 ? `\nNext steps:\n\n${sections.join('\n\n')}\n` : ''

--- a/packages/create/src/edge-create-app.ts
+++ b/packages/create/src/edge-create-app.ts
@@ -7,6 +7,7 @@ import { resolvePackageJSONLatest } from './npm-resolver.js'
 import { writeConfigFileToEnvironment } from './edge-config-file.js'
 import {
   getPackageManagerExecuteCommand,
+  getPackageManagerInstallCommand,
   getPackageManagerScriptCommand,
   packageManagerInstall,
   translateExecuteCommand,
@@ -252,6 +253,19 @@ async function setupIntent(
   options: Options,
 ) {
   if (!options.intent) {
+    return
+  }
+
+  if (options.install === false) {
+    environment.startStep({
+      id: 'setup-intent',
+      type: 'info',
+      message: 'Skipping TanStack Intent setup...',
+    })
+    environment.finishStep(
+      'setup-intent',
+      'TanStack Intent setup skipped: no dependencies installed yet',
+    )
     return
   }
 
@@ -531,9 +545,24 @@ function buildNextSteps(options: Options): string {
     sections.push(`Docs for the integrations you picked:\n${docLines.join('\n')}`)
   }
   if (options.intent) {
-    sections.push(
-      `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nwith explicit skill mappings for the libraries you installed. Try asking your agent:\n  - "migrate this Next.js page to TanStack Start"\n  - "add a protected /dashboard route"\n  - "show me how to use TanStack Router search params"`,
-    )
+    if (options.install === false) {
+      const installCommand = formatCommand(
+        getPackageManagerInstallCommand(options.packageManager),
+      )
+      const intentCommand = formatCommand(
+        getPackageManagerExecuteCommand(options.packageManager, '@tanstack/intent', [
+          'install',
+          '--map',
+        ]),
+      )
+      sections.push(
+        `Working with an AI agent? TanStack Intent was skipped because dependency installation was\nskipped, so no agent config (AGENTS.md / CLAUDE.md) was written. After installing dependencies,\nwire it up with:\n  % ${installCommand}\n  % ${intentCommand}`,
+      )
+    } else {
+      sections.push(
+        `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nwith explicit skill mappings for the libraries you installed. Try asking your agent:\n  - "migrate this Next.js page to TanStack Start"\n  - "add a protected /dashboard route"\n  - "show me how to use TanStack Router search params"`,
+      )
+    }
   }
 
   return sections.length > 0 ? `\nNext steps:\n\n${sections.join('\n\n')}\n` : ''

--- a/packages/create/src/integrations/intent.ts
+++ b/packages/create/src/integrations/intent.ts
@@ -13,6 +13,22 @@ export async function setupIntent(
     return
   }
 
+  if (options.install === false) {
+    const s = environment.spinner()
+    s.start('Skipping TanStack Intent setup...')
+    environment.startStep({
+      id: 'setup-intent',
+      type: 'info',
+      message: 'Skipping TanStack Intent setup...',
+    })
+    environment.finishStep(
+      'setup-intent',
+      'TanStack Intent setup skipped: no dependencies installed yet',
+    )
+    s.stop('TanStack Intent setup skipped: no dependencies installed yet')
+    return
+  }
+
   const s = environment.spinner()
   s.start('Setting up TanStack Intent skill mappings...')
   environment.startStep({

--- a/packages/create/tests/create-app.test.ts
+++ b/packages/create/tests/create-app.test.ts
@@ -124,6 +124,48 @@ describe('createApp', () => {
     })
   })
 
+  it('skips intent setup and reports the follow-up when dependency install is skipped', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    let outro = ''
+    environment.outro = (message: string) => {
+      outro = message
+    }
+    await createApp(environment, {
+      ...simpleOptions,
+      intent: true,
+      install: false,
+    })
+
+    expect(output.commands).not.toContainEqual({
+      command: 'pnpm',
+      args: ['dlx', '@tanstack/intent', 'install', '--map'],
+    })
+    expect(outro).not.toContain('was wired up by TanStack Intent')
+    expect(outro).toContain('TanStack Intent was skipped')
+    expect(outro).toContain('pnpm install')
+    expect(outro).toContain('pnpm dlx @tanstack/intent install --map')
+  })
+
+  it('sets up intent and reports the agent config when dependencies are installed', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    let outro = ''
+    environment.outro = (message: string) => {
+      outro = message
+    }
+    await createApp(environment, {
+      ...simpleOptions,
+      intent: true,
+      install: true,
+    })
+
+    expect(output.commands).toContainEqual({
+      command: 'pnpm',
+      args: ['dlx', '@tanstack/intent', 'install', '--map'],
+    })
+    expect(outro).toContain('was wired up by TanStack Intent')
+    expect(outro).not.toContain('TanStack Intent was skipped')
+  })
+
   it('should create an app - with a add-on', async () => {
     const { environment, output } = createMemoryEnvironment()
     await createApp(environment, {

--- a/packages/create/tests/integrations/intent.test.ts
+++ b/packages/create/tests/integrations/intent.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMemoryEnvironment } from '../../src/environment.js'
+import { setupIntent } from '../../src/integrations/intent.js'
+
+import type { Options } from '../../src/types.js'
+
+describe('intent', () => {
+  it('should skip if intent is not enabled', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    environment.startRun()
+    await setupIntent(environment, '/test', {
+      packageManager: 'pnpm',
+      intent: false,
+      projectName: 'test',
+      typescript: true,
+      spinner: () => ({
+        start: () => {},
+        stop: () => {},
+      }),
+    } as unknown as Options)
+    environment.finishRun()
+
+    expect(output.commands).toEqual([])
+  })
+
+  it('should run the intent install command when dependencies are installed', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    environment.startRun()
+    await setupIntent(environment, '/test', {
+      packageManager: 'pnpm',
+      intent: true,
+      install: true,
+      projectName: 'test',
+      typescript: true,
+      spinner: () => ({
+        start: () => {},
+        stop: () => {},
+      }),
+    } as unknown as Options)
+    environment.finishRun()
+
+    expect(output.commands).toEqual([
+      {
+        command: 'pnpm',
+        args: ['dlx', '@tanstack/intent', 'install', '--map'],
+      },
+    ])
+  })
+
+  it('should skip the intent install command when dependency install is skipped', async () => {
+    const { environment, output } = createMemoryEnvironment()
+    environment.startRun()
+    await setupIntent(environment, '/test', {
+      packageManager: 'pnpm',
+      intent: true,
+      install: false,
+      projectName: 'test',
+      typescript: true,
+      spinner: () => ({
+        start: () => {},
+        stop: () => {},
+      }),
+    } as unknown as Options)
+    environment.finishRun()
+
+    expect(output.commands).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #495, reported by @shivss26.

`create --no-install` printed "TanStack Intent configured" and the outro claimed the agent config "was wired up", but no AGENTS.md exists: `setupIntent` runs `@tanstack/intent install --map`, which discovers skills by walking installed `node_modules`, so with nothing installed it writes nothing.

Actually writing AGENTS.md without installing is not feasible from this repo (`@tanstack/intent` is external and needs packages on disk), so this makes the reporting honest instead: `create-app` and `edge-create-app` now skip the Intent step when `install === false`, print "TanStack Intent setup skipped: no dependencies installed yet", and the next-steps output shows the exact package-manager-aware follow-up (`pnpm install`, then `pnpm dlx @tanstack/intent install --map`).

Five regression tests cover the skip behavior, the outro text, and the unchanged installed-path behavior. packages/create: 253 passed; packages/cli: 101 passed; zero new failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TanStack Intent setup now respects the dependency installation option.
  * When installation is skipped, setup is deferred and clear commands are provided for completing it later.
  * Next-step guidance now accurately reflects whether Intent configuration was completed or skipped.

* **Bug Fixes**
  * Prevented Intent setup commands from running when dependencies are not installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->