### PR TITLE
Use intent discovery mode instead of inlining the skill map into AGENTS.md

### DIFF
--- a/.changeset/lean-intent-skill-guidance.md
+++ b/.changeset/lean-intent-skill-guidance.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/create': patch
+---
+
+Wire TanStack Intent up in on-demand discovery mode instead of writing the full
+skill-to-task mapping table into `AGENTS.md`. Generated projects previously got
+an `install --map` block listing every skill for every installed package — 99
+lines in a default app, growing with each add-on — which every agent re-read on
+every invocation. Plain `install` emits a 12-line pointer telling the agent to
+run `intent list` and `intent load <package>#<skill>` when a task actually calls
+for one. The "next steps" output now shows those two commands, rendered for the
+project's package manager.

--- a/.changeset/lean-intent-skill-guidance.md
+++ b/.changeset/lean-intent-skill-guidance.md
@@ -6,7 +6,7 @@ Wire TanStack Intent up in on-demand discovery mode instead of writing the full
 skill-to-task mapping table into `AGENTS.md`. Generated projects previously got
 an `install --map` block listing every skill for every installed package — 99
 lines in a default app, growing with each add-on — which every agent re-read on
-every invocation. Plain `install` emits a 12-line pointer telling the agent to
+every invocation. Plain `install` emits a 10-line pointer telling the agent to
 run `intent list` and `intent load <package>#<skill>` when a task actually calls
 for one. The "next steps" output now shows those two commands, rendered for the
 project's package manager.

--- a/packages/create/src/create-app.ts
+++ b/packages/create/src/create-app.ts
@@ -5,6 +5,7 @@ import { formatCommand } from './utils.js'
 import { writeConfigFileToEnvironment } from './config-file.js'
 import {
   getPackageManagerScriptCommand,
+  intentCommand,
   packageManagerInstall,
   translateExecuteCommand,
 } from './package-manager.js'
@@ -414,7 +415,7 @@ function buildNextSteps(options: Options): string {
   }
   if (options.intent) {
     sections.push(
-      `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nwith explicit skill mappings for the libraries you installed. Try asking your agent:\n  • "migrate this Next.js page to TanStack Start"\n  • "add a protected /dashboard route"\n  • "show me how to use TanStack Router search params"`,
+      `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nso your agent can discover skills for the libraries you installed, on demand:\n  • ${intentCommand(options.packageManager, ['list'])}\n  • ${intentCommand(options.packageManager, ['load', '<package>#<skill>'])}\nTry asking your agent:\n  • "migrate this Next.js page to TanStack Start"\n  • "add a protected /dashboard route"\n  • "show me how to use TanStack Router search params"`,
     )
   }
 

--- a/packages/create/src/edge-create-app.ts
+++ b/packages/create/src/edge-create-app.ts
@@ -6,8 +6,10 @@ import { basenamePath, joinPaths, normalizePath } from './edge-path.js'
 import { resolvePackageJSONLatest } from './npm-resolver.js'
 import { writeConfigFileToEnvironment } from './edge-config-file.js'
 import {
+  INTENT_PACKAGE,
   getPackageManagerExecuteCommand,
   getPackageManagerScriptCommand,
+  intentCommand,
   packageManagerInstall,
   translateExecuteCommand,
 } from './package-manager.js'
@@ -258,13 +260,13 @@ async function setupIntent(
   environment.startStep({
     id: 'setup-intent',
     type: 'command',
-    message: 'Setting up TanStack Intent skill mappings...',
+    message: 'Setting up TanStack Intent skill discovery...',
   })
 
   const { command, args } = getPackageManagerExecuteCommand(
     options.packageManager,
-    '@tanstack/intent',
-    ['install', '--map'],
+    INTENT_PACKAGE,
+    ['install'],
   )
   await environment.execute(command, args, normalizePath(targetDir))
   environment.finishStep('setup-intent', 'TanStack Intent configured')
@@ -532,7 +534,7 @@ function buildNextSteps(options: Options): string {
   }
   if (options.intent) {
     sections.push(
-      `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nwith explicit skill mappings for the libraries you installed. Try asking your agent:\n  - "migrate this Next.js page to TanStack Start"\n  - "add a protected /dashboard route"\n  - "show me how to use TanStack Router search params"`,
+      `Working with an AI agent? Your agent config (AGENTS.md / CLAUDE.md) was wired up by TanStack Intent\nso your agent can discover skills for the libraries you installed, on demand:\n  - ${intentCommand(options.packageManager, ['list'])}\n  - ${intentCommand(options.packageManager, ['load', '<package>#<skill>'])}\nTry asking your agent:\n  - "migrate this Next.js page to TanStack Start"\n  - "add a protected /dashboard route"\n  - "show me how to use TanStack Router search params"`,
     )
   }
 

--- a/packages/create/src/integrations/intent.ts
+++ b/packages/create/src/integrations/intent.ts
@@ -1,6 +1,10 @@
 import { resolve } from 'node:path'
 
-import { packageManagerExecute } from '../package-manager.js'
+import {
+  INTENT_PACKAGE,
+  intentCommand,
+  packageManagerExecute,
+} from '../package-manager.js'
 
 import type { Environment, Options } from '../types.js'
 
@@ -14,11 +18,11 @@ export async function setupIntent(
   }
 
   const s = environment.spinner()
-  s.start('Setting up TanStack Intent skill mappings...')
+  s.start('Setting up TanStack Intent skill discovery...')
   environment.startStep({
     id: 'setup-intent',
     type: 'command',
-    message: 'Setting up TanStack Intent skill mappings...',
+    message: 'Setting up TanStack Intent skill discovery...',
   })
 
   try {
@@ -26,8 +30,8 @@ export async function setupIntent(
       environment,
       resolve(targetDir),
       options.packageManager,
-      '@tanstack/intent',
-      ['install', '--map'],
+      INTENT_PACKAGE,
+      ['install'],
     )
     environment.finishStep('setup-intent', 'TanStack Intent configured')
     s.stop('TanStack Intent configured')
@@ -41,7 +45,7 @@ export async function setupIntent(
     s.stop('TanStack Intent setup skipped')
     environment.warn(
       'TanStack Intent setup failed',
-      `Continuing without it. You can run it later with: npx @tanstack/intent install\n\n${message}`,
+      `Continuing without it. You can run it later with: ${intentCommand(options.packageManager, ['install'])}\n\n${message}`,
     )
   }
 }

--- a/packages/create/src/package-manager.ts
+++ b/packages/create/src/package-manager.ts
@@ -61,6 +61,22 @@ export function getPackageManagerExecuteCommand(
   }
 }
 
+export const INTENT_PACKAGE = '@tanstack/intent'
+
+// Renders the command a user (or their agent) would type to reach Intent, so the
+// suggestions we print match the package manager the project was created with.
+export function intentCommand(
+  packageManager: PackageManager,
+  args: Array<string>,
+) {
+  const { command, args: commandArgs } = getPackageManagerExecuteCommand(
+    packageManager,
+    INTENT_PACKAGE,
+    args,
+  )
+  return [command, ...commandArgs].join(' ')
+}
+
 export function getPackageManagerInstallCommand(
   packagerManager: PackageManager,
   pkg?: string,

--- a/packages/create/src/package-manager.ts
+++ b/packages/create/src/package-manager.ts
@@ -63,8 +63,6 @@ export function getPackageManagerExecuteCommand(
 
 export const INTENT_PACKAGE = '@tanstack/intent'
 
-// Renders the command a user (or their agent) would type to reach Intent, so the
-// suggestions we print match the package manager the project was created with.
 export function intentCommand(
   packageManager: PackageManager,
   args: Array<string>,


### PR DESCRIPTION
Hey folks, I spun up a project with a lot of integrations and noticed my agent
constantly surfacing TanStack Intent skills. Great feature, but I have a concern
about how it's delivered.

`intent install --map` writes the full skill to task table into AGENTS.md. That's
99 lines / ~14 KB on a default app before any add-ons. My project (15 add-ons:
query, table, db, better-auth, drizzle, sentry, mcp, shadcn and others) came out
at 157 lines / 26.8 KB / 51 skills.

AGENTS.md is re-read on essentially every invocation, so that catalog gets paid
for on every turn regardless of whether the task touches those libraries. In my
case the agent kept pulling frontend router/query skills while I was working on
unrelated backend code.

The catalog already lives in the installed packages, and `intent list` reads it
on demand. Inlining it into AGENTS.md duplicates it into the one file that's most
expensive to bloat. Growth also tracks TanStack packages that ship skills, and
the ones people actually reach for (db, table, query, router, start) all do.

## What this PR does

Drops `--map` so intent uses its own default mode: a 10-line pointer telling the
agent to run `intent list` / `intent load <package>#<skill>` when a task actually
calls for one.

Also updates the now-inaccurate "explicit skill mappings" copy in the next-steps
output to surface the two discovery commands, rendered for the project's package
manager.

| | Lines | Bytes | Skills |
|---|---|---|---|
| Default app (query only) | 99 | 14,157 | 31 |
| 15-add-on app | 157 | 26,777 | 51 |
| After this PR | 10 | 721 | — |

26,777 → 721 bytes on my project, a 97% cut. 99 → 10 lines on a default app.

Worth noting this doesn't remove any information: the catalog stays exactly where
it already is, in the installed packages. It just stops being copied into the
context on every turn.

Happy to add an opt-in `--intent-map` flag if you'd rather keep the eager table
available for people who want it, same as the prompt for initializing a git repo
at the end of the create CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated AI agent setup to use on-demand skill discovery instead of generating complete skill mappings.
  * Added guidance to list available skills and load specific skills as needed.
  * Added package-manager-aware commands for installing and using TanStack Intent.

* **Documentation**
  * Updated generated setup instructions and next steps with Intent discovery commands and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->