### PR TITLE
fix: drop dead imports from generated React templates

### DIFF
--- a/.changeset/router-unused-imports.md
+++ b/.changeset/router-unused-imports.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/create': patch
+---
+
+Drop unused React Query imports from the generated React `router.tsx`. The
+`tanstack-query` branch imported `ReactNode`, `QueryClient` and the
+`TanstackQueryProvider` default export whenever the add-on was enabled, but
+`ReactNode` and `TanstackQueryProvider` are only referenced inside the tRPC
+`Wrap` block and `QueryClient` was never referenced at all. Generated projects
+set `noUnusedLocals: true`, so a fresh scaffold shipped code that violates its
+own tsconfig. The two tRPC-only imports are now gated behind
+`addOnEnabled.tRPC` and the `QueryClient` import is removed.

--- a/.changeset/trpc-dead-imports.md
+++ b/.changeset/trpc-dead-imports.md
@@ -1,0 +1,12 @@
+---
+'@tanstack/create': patch
+---
+
+Drop two dead imports from the generated tRPC integration. `api.trpc.$.tsx`
+imported `createServerFileRoute` from `@tanstack/react-start/server`, but the
+route was already migrated to `createFileRoute(...)({ server: { handlers } })`
+and that symbol is no longer exported, so the leftover import was both unused
+and unresolvable. The tRPC branch of `root-provider.tsx` imported
+`QueryClientProvider`, which it never renders —
+`setupRouterSsrQueryIntegration` supplies the query client. Generated projects
+set `noUnusedLocals: true`, so both showed up as errors in a fresh scaffold.

--- a/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/routes/api.trpc.$.tsx
+++ b/packages/create/src/frameworks/react/add-ons/tRPC/assets/src/routes/api.trpc.$.tsx
@@ -1,4 +1,3 @@
-import { createServerFileRoute } from '@tanstack/react-start/server'
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
 import { trpcRouter } from '#/integrations/trpc/router'
 import { createFileRoute } from '@tanstack/react-router'

--- a/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
+++ b/packages/create/src/frameworks/react/add-ons/tanstack-query/assets/src/integrations/tanstack-query/root-provider.tsx.ejs
@@ -1,6 +1,6 @@
 <% if (addOnEnabled.tRPC) { %>
 import type { ReactNode } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import superjson from "superjson";
 import { createTRPCClient, httpBatchStreamLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";

--- a/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
@@ -1,10 +1,9 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
-<% if (addOnEnabled['tanstack-query']) { %>
-import type { ReactNode } from 'react'
-import { QueryClient } from '@tanstack/react-query'
+<% if (addOnEnabled['tanstack-query']) { %><% if (addOnEnabled.tRPC) { %>
+import type { ReactNode } from 'react'<% } %>
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
-import TanstackQueryProvider, { getContext } from './integrations/tanstack-query/root-provider'
+import <% if (addOnEnabled.tRPC) { %>TanstackQueryProvider, <% } %>{ getContext } from './integrations/tanstack-query/root-provider'
 <% } %>
 
 export function getRouter() {


### PR DESCRIPTION
<html><head></head><body><p>Every fresh scaffold that includes <code>tanstack-query</code> ships TypeScript errors out
of the box. Generated projects set <code>noUnusedLocals: true</code>, and three imports in
the templates are never used, all residue of earlier migrations that moved the
code but left the import lines behind.</p>
<p>To be precise about severity: this is <strong>not</strong> a broken build. <code>vite build</code>
doesn't typecheck (esbuild strips types), so the apps build and run fine. It's
red squiggles in every new project from the second it opens in an editor, and a
hard failure the moment anyone runs <code>tsc</code>.</p>
<h2>Reproduce</h2>
<pre><code class="language-bash">npx @tanstack/cli create demo --add-ons tanstack-query -y
cd demo &amp;&amp; npx tsc --noEmit
</code></pre>
<pre><code>src/router.tsx(4,1): error TS6133: 'ReactNode' is declared but its value is never read.
src/router.tsx(5,1): error TS6133: 'QueryClient' is declared but its value is never read.
src/router.tsx(7,8): error TS6133: 'TanstackQueryProvider' is declared but its value is never read.
</code></pre>
<p>Add <code>tRPC</code> and you also get:</p>
<pre><code>src/integrations/tanstack-query/root-provider.tsx(2,23): error TS6133: 'QueryClientProvider' is declared but its value is never read.
src/routes/api.trpc.$.tsx(1,1): error TS6133: 'createServerFileRoute' is declared but its value is never read.
src/routes/api.trpc.$.tsx(1,10): error TS2305: Module '"@tanstack/react-start/server"' has no exported member 'createServerFileRoute'.
</code></pre>
<h2>What's wrong</h2>
<p><strong>1. <code>project/base/src/router.tsx.ejs</code></strong> (commit 1) — the <code>tanstack-query</code>
branch imports four things, but <code>QueryClient</code> is never referenced in any branch,
and <code>ReactNode</code> / the <code>TanstackQueryProvider</code> default export are referenced only
inside the <code>addOnEnabled.tRPC</code> Wrap block. Only <code>getContext</code> and
<code>setupRouterSsrQueryIntegration</code> are used unconditionally. Fix: gate the two
tRPC-only imports behind <code>addOnEnabled.tRPC</code>, delete <code>QueryClient</code>.</p>
<p><strong>2. <code>add-ons/tRPC/assets/src/routes/api.trpc.$.tsx</code></strong> (commit 2) — imports
<code>createServerFileRoute</code>, but the route body already uses the current API
(<code>createFileRoute</code> with <code>server: { handlers: ... }</code>). The migration landed, the
import didn't get removed. That symbol is no longer exported at all, so it's
both unused and unresolvable.</p>
<p><strong>3. <code>add-ons/tanstack-query/.../root-provider.tsx.ejs</code></strong> (commit 2) — the tRPC
branch imports <code>QueryClientProvider</code> but renders <code>TRPCProvider</code>;
<code>setupRouterSsrQueryIntegration</code> is what supplies the query client.</p>
<p><code>setupRouterSsrQueryIntegration</code> is deliberately left alone — it's used further
down the router template, and removing it silently breaks SSR query dehydration.
Solid's <code>router.tsx.ejs</code> is already correct.</p>
<p>Split into two commits, one per concern, with a changeset each.</p>
<h2>Verification</h2>
<p>Scaffolded with the built CLI, fully installed, typechecked and built:</p>

Scaffold | Before | After
-- | -- | --
--add-ons tanstack-query | 3 errors | tsc --noEmit exit 0
--add-ons tanstack-query,tRPC | 4 errors | 1 error (unrelated, below)


<p><code>vite build</code> on the tRPC scaffold: exit 0. Unit suites green — 101
<code>@tanstack/cli</code>, 248 <code>@tanstack/create</code>.</p>

<h2>Prior art</h2>
<p>Issue #272 ("Provider ... is not used"), closed by #356. The router imports are
leftover residue of that fix — the Wrap block got gated, the imports did not.
Not a duplicate, the still-live remainder.</p></body></html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated React projects with TanStack Query and tRPC so they no longer include unused or invalid imports.
  * Corrected the generated tRPC API route to properly handle both GET and POST requests.
  * Resolved scaffold validation errors when unused-local checks are enabled.
* **Chores**
  * Added release notes documenting the generated project fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->