### PR TITLE
docs: use the dynamic README header endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <h1>TanStack CLI</h1>
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/cli.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/cli.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/cli.png"
+      alt="TanStack CLI"
+      width="900"
+    />
+  </picture>
 </div>
 
 <div align="center">


### PR DESCRIPTION
Adopts the dynamic README header endpoint added in TanStack/tanstack.com#1076,
which is merged and live.

Every README banner in this repo now points a `<picture>` at
`https://tanstack.com/api/readme/` instead of a committed PNG. The endpoint
renders 1800x450 in light and dark, so a branding change lands in every README
at once and dark-mode readers get a dark banner.

## What changed

- 1 README(s) updated.
- Light and dark served through `<picture>`, per [GitHub's guidance](https://github.blog/developer-skills/github/how-to-make-your-images-in-markdown-on-github-adjust-for-dark-mode-and-light-mode/). The trailing `<img>` stays the light variant, as the fallback for renderers that ignore `<picture>` (npm, most editors).



`cli` had no banner at all - just a duplicated `<h1>TanStack CLI</h1>`. It now gets one, for parity with the other library repos.

## Verification

Every generated URL in this diff was requested against the live endpoint and
returned `200 image/png` at 1800x450. `git grep` confirms no README still
references the old `media/header_*.png` path.

Heads up: deleting the committed PNG means npm pages for **already-published**
versions that embed the `raw.githubusercontent.com/.../main/media/header_*.png`
link will show a broken image, since that link is branch-pinned. New releases
pick up the endpoint URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README header with a responsive, theme-aware image.
  * Added light and dark display variants with an accessible fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->