### PR TITLE
fix Paraglide Start scaffold integration

### DIFF
--- a/.changeset/fuzzy-ravens-route.md
+++ b/.changeset/fuzzy-ravens-route.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/create': patch
+---
+
+Configure the Paraglide add-on with TanStack Router URL rewrites and request-scoped server middleware.

--- a/packages/create/src/frameworks/react/add-ons/paraglide/assets/src/server.ts.ejs
+++ b/packages/create/src/frameworks/react/add-ons/paraglide/assets/src/server.ts.ejs
@@ -1,0 +1,8 @@
+import { paraglideMiddleware } from './paraglide/server.js'
+import handler from '@tanstack/react-start/server-entry'
+
+export default {
+  fetch(req: Request): Promise<Response> {
+    return paraglideMiddleware(req, () => handler.fetch(req))
+  },
+}

--- a/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
+++ b/packages/create/src/frameworks/react/project/base/src/router.tsx.ejs
@@ -1,5 +1,8 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
+<% if (addOnEnabled.paraglide) { %>
+import { deLocalizeUrl, localizeUrl } from './paraglide/runtime'
+<% } %>
 <% if (addOnEnabled['tanstack-query']) { %>
 import type { ReactNode } from 'react'
 import { QueryClient } from '@tanstack/react-query'
@@ -20,6 +23,12 @@ export function getRouter() {
     scrollRestoration: true,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
+    <% if (addOnEnabled.paraglide) { %>
+    rewrite: {
+      input: ({ url }) => deLocalizeUrl(url),
+      output: ({ url }) => localizeUrl(url),
+    },
+    <% } %>
     <% if (addOnEnabled.tRPC) { %>
     Wrap: (props: { children: ReactNode }) => {
       return (

--- a/packages/create/tests/paraglide-addon.test.ts
+++ b/packages/create/tests/paraglide-addon.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  finalizeAddOns,
+  populateAddOnOptionsDefaults,
+} from '../src/add-ons.js'
+import { createApp } from '../src/create-app.js'
+import { createMemoryEnvironment } from '../src/environment.js'
+import { createFrameworkDefinition } from '../src/frameworks/react/index.js'
+
+import type { Framework, FrameworkDefinition, Options } from '../src/types.js'
+
+function frameworkFromDefinition(definition: FrameworkDefinition): Framework {
+  const { addOns, base, ...framework } = definition
+
+  return {
+    ...framework,
+    getFiles: () => Promise.resolve(Object.keys(base)),
+    getFileContents: (path: string) => Promise.resolve(base[path]),
+    getDeletedFiles: () => Promise.resolve([]),
+    getAddOns: () => addOns,
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('Paraglide add-on', () => {
+  it('configures localized routing and request-scoped SSR', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ version: '1.0.0' }), { status: 200 }),
+      ),
+    )
+
+    const framework = frameworkFromDefinition(createFrameworkDefinition())
+    const chosenAddOns = await finalizeAddOns(framework, 'file-router', [
+      'paraglide',
+    ])
+    const options = {
+      projectName: 'paraglide-app',
+      targetDir: '/paraglide-app',
+      framework,
+      mode: 'file-router',
+      typescript: true,
+      tailwind: true,
+      packageManager: 'pnpm',
+      git: false,
+      install: false,
+      intent: false,
+      includeExamples: true,
+      chosenAddOns,
+      addOnOptions: populateAddOnOptionsDefaults(chosenAddOns),
+    } as Options
+    const { environment, output } = createMemoryEnvironment()
+
+    await createApp(environment, options)
+
+    const router = output.files['/paraglide-app/src/router.tsx']
+    expect(router).toContain(
+      "import { deLocalizeUrl, localizeUrl } from './paraglide/runtime'",
+    )
+    expect(router).toContain('input: ({ url }) => deLocalizeUrl(url)')
+    expect(router).toContain('output: ({ url }) => localizeUrl(url)')
+
+    const server = output.files['/paraglide-app/src/server.ts']
+    expect(server).toContain(
+      "import { paraglideMiddleware } from './paraglide/server.js'",
+    )
+    expect(server).toContain(
+      "import handler from '@tanstack/react-start/server-entry'",
+    )
+    expect(server).toContain(
+      'return paraglideMiddleware(req, () => handler.fetch(req))',
+    )
+  })
+})


### PR DESCRIPTION
> Disclaimer: This PR has been created with GTP 5.6 Sol after investigating https://github.com/opral/paraglide-js/issues/739. 

## What changed

- generate TanStack Router URL rewrites when the Paraglide add-on is selected
- generate a TanStack Start server entry wrapped in `paraglideMiddleware`
- add regression coverage for both integration points and a patch changeset

## Why

The Paraglide add-on generated locale-switching UI, but omitted the URL rewrite and server middleware shown in the official TanStack i18n setup. A switch to German navigated to `/de`, which the router treated as an unmatched route, while SSR continued rendering the fallback locale. The resulting server/client disagreement caused not-found warnings and hydration failures on every locale switch.

Related: https://github.com/opral/paraglide-js/issues/739

## Validation

- repository pre-commit hook: all 10 project builds passed
- unit suites: 32 files / 251 tests in `@tanstack/create`, and 7 files / 101 tests in `@tanstack/cli`
- blocking Playwright suite: 7 tests passed
- generated a local React + Paraglide scaffold and verified `src/router.tsx` and `src/server.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Paraglide localization support for TanStack Router URL rewrites.
  * Added request-scoped server middleware to localize incoming and outgoing requests.
  * Generated applications now support localized routing with server-side rendering.

* **Tests**
  * Added coverage verifying localized router and server middleware generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->