### PR TITLE
refactor(create): rebuild AI Assistant on @tanstack/ai-react/ui createChatHook

### DIFF
--- a/.changeset/ai-assistant-react-ui.md
+++ b/.changeset/ai-assistant-react-ui.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/create': patch
+---
+
+Rebuild the React AI add-on's floating "AI Assistant" on the
+`@tanstack/ai-react/ui` `createChatHook` registry pattern. The assistant now
+registers layout/message/input chrome plus text and `recommendGuitar` tool
+components instead of hand-rolling message rendering, matching the newer
+react-ui chat architecture. Behaviour and styling are unchanged; the guitar
+recommendation card still renders inline.

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/ai/demo-ai-ui-context.ts
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/ai/demo-ai-ui-context.ts
@@ -1,0 +1,6 @@
+import { createChatHookContexts } from '@tanstack/ai-react/ui'
+
+// Scoped contexts so the registered chrome/part/tool widgets can read the
+// chat instance even though they live in separate files from the hook.
+export const { chatContext, partContext, interruptContext } =
+  createChatHookContexts()

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/ai/demo-chat-registry.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/ai/demo-chat-registry.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'react'
+import { createChatHook } from '@tanstack/ai-react/ui'
+import type {
+  LayoutProps,
+  MessageProps,
+  PartProps,
+  ToolProps,
+} from '@tanstack/ai-react/ui'
+
+import { Send } from 'lucide-react'
+import { Streamdown } from 'streamdown'
+
+import { chatOptions } from '#/lib/demo-ai-hook'
+import GuitarRecommendation from '#/components/demo-GuitarRecommendation'
+
+import {
+  chatContext,
+  interruptContext,
+  partContext,
+} from './demo-ai-ui-context'
+
+// The chrome around the message list. `Messages` and `Input` are supplied by
+// the kit; this component owns the scroll container and auto-scroll behaviour.
+function ChatLayout({ Messages, Input }: LayoutProps<typeof chatOptions>) {
+  const chat = useChatContext()
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [chat.messages])
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {chat.error ? (
+        <p className="p-4 text-sm text-red-500">{chat.error.message}</p>
+      ) : null}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+        {chat.messages.length === 0 ? (
+          <div className="demo-muted flex h-full items-center justify-center text-sm">
+            Ask me anything! I'm here to help.
+          </div>
+        ) : (
+          <Messages />
+        )}
+      </div>
+      <div className="border-t border-[var(--line)] p-3">
+        <Input />
+      </div>
+    </div>
+  )
+}
+
+// One message row: an avatar chip plus the automatically-dispatched parts.
+function ChatMessage({ message, Parts }: MessageProps<typeof chatOptions>) {
+  const isAssistant = message.role === 'assistant'
+  return (
+    <div className={`py-3 ${isAssistant ? 'bg-[var(--chip-bg)]' : ''}`}>
+      <div className="flex items-start gap-2 px-4">
+        <div
+          className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-lg text-xs font-medium text-white ${
+            isAssistant ? 'bg-[var(--lagoon-deep)]' : 'bg-[var(--sea-ink-soft)]'
+          }`}
+        >
+          {isAssistant ? 'AI' : 'Y'}
+        </div>
+        <div className="min-w-0 flex-1 max-w-none text-sm text-[var(--sea-ink)]">
+          <Parts />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// The message composer.
+function ChatInput() {
+  const chat = useChatContext()
+  const [input, setInput] = useState('')
+
+  const send = () => {
+    const trimmed = input.trim()
+    if (!trimmed) return
+    void chat.sendMessage(trimmed)
+    setInput('')
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        send()
+      }}
+    >
+      <div className="relative">
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type your message..."
+          className="demo-textarea pr-10 text-sm"
+          rows={1}
+          style={{ minHeight: '36px', maxHeight: '120px' }}
+          onInput={(e) => {
+            const target = e.target as HTMLTextAreaElement
+            target.style.height = 'auto'
+            target.style.height = Math.min(target.scrollHeight, 120) + 'px'
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              send()
+            }
+          }}
+        />
+        <button
+          type="submit"
+          disabled={!input.trim()}
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-[var(--lagoon-deep)] transition-colors hover:text-[var(--sea-ink)] disabled:text-[var(--sea-ink-soft)]"
+        >
+          <Send className="w-4 h-4" />
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// Markdown text part.
+function TextPart({ part }: PartProps<typeof chatOptions, 'text'>) {
+  if (!part.content) return null
+  return <Streamdown>{part.content}</Streamdown>
+}
+
+// Anything the assistant emits that we don't render explicitly (e.g. the
+// server-side getGuitars lookup) is intentionally suppressed.
+function FallbackPart() {
+  return null
+}
+
+// The recommendGuitar client tool renders the rich guitar card.
+function RecommendGuitarTool({
+  part,
+}: ToolProps<typeof chatOptions, 'recommendGuitar'>) {
+  if (!part.output) return null
+  return (
+    <div className="mx-auto max-w-[80%]">
+      <GuitarRecommendation id={String(part.output.id)} />
+    </div>
+  )
+}
+
+export const { useAppChat, useChatContext } = createChatHook({
+  options: chatOptions,
+  context: {
+    chatContext,
+    partContext,
+    interruptContext,
+  },
+  components: {
+    layout: ChatLayout,
+    message: ChatMessage,
+    input: ChatInput,
+  },
+  partsComponents: {
+    text: TextPart,
+    fallback: FallbackPart,
+  },
+  toolsComponents: {
+    recommendGuitar: RecommendGuitarTool,
+  },
+})

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/components/demo-AIAssistant.tsx
@@ -1,85 +1,15 @@
-import { useEffect, useRef, useState } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { Store } from '@tanstack/store'
 
-import { Send, X, ChevronRight, BotIcon } from 'lucide-react'
-import { Streamdown } from 'streamdown'
+import { X, ChevronRight, BotIcon } from 'lucide-react'
 
-import { useGuitarRecommendationChat } from '#/lib/demo-ai-hook'
-import type { ChatMessages } from '#/lib/demo-ai-hook'
-
-import GuitarRecommendation from './demo-GuitarRecommendation'
+import { useAppChat } from './ai/demo-chat-registry'
 
 export const showAIAssistant = new Store(false)
 
-function Messages({ messages }: { messages: ChatMessages }) {
-  const messagesContainerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (messagesContainerRef.current) {
-      messagesContainerRef.current.scrollTop =
-        messagesContainerRef.current.scrollHeight
-    }
-  }, [messages])
-
-  if (!messages.length) {
-    return (
-      <div className="demo-muted flex flex-1 items-center justify-center text-sm">
-        Ask me anything! I'm here to help.
-      </div>
-    )
-  }
-
-  return (
-    <div ref={messagesContainerRef} className="flex-1 overflow-y-auto">
-      {messages.map(({ id, role, parts }) => (
-        <div
-          key={id}
-          className={`py-3 ${
-            role === 'assistant' ? 'bg-[var(--chip-bg)]' : 'bg-transparent'
-          }`}
-        >
-          {parts.map((part, index) => {
-            if (part.type === 'text' && part.content) {
-              return (
-                <div key={index} className="flex items-start gap-2 px-4">
-                  {role === 'assistant' ? (
-                    <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--lagoon-deep)] text-xs font-medium text-white">
-                      AI
-                    </div>
-                  ) : (
-                    <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--sea-ink-soft)] text-xs font-medium text-white">
-                      Y
-                    </div>
-                  )}
-                  <div className="min-w-0 flex-1 max-w-none text-sm text-[var(--sea-ink)]">
-                    <Streamdown>{part.content}</Streamdown>
-                  </div>
-                </div>
-              )
-            }
-            if (
-              part.type === 'tool-call' &&
-              part.name === 'recommendGuitar' &&
-              part.output
-            ) {
-              return (
-                <div key={part.id} className="max-w-[80%] mx-auto">
-                  <GuitarRecommendation id={String(part.output?.id)} />
-                </div>
-              )
-            }
-          })}
-        </div>
-      ))}
-    </div>
-  )
-}
-
 export default function AIAssistant() {
   const isOpen = useStore(showAIAssistant, (state) => state)
-  const { messages, sendMessage } = useGuitarRecommendationChat()
-  const [input, setInput] = useState('')
+  const chat = useAppChat()
 
   return (
     <div className="relative z-50">
@@ -108,50 +38,7 @@ export default function AIAssistant() {
             </button>
           </div>
 
-          <Messages messages={messages} />
-
-          <div className="border-t border-[var(--line)] p-3">
-            <form
-              onSubmit={(e) => {
-                e.preventDefault()
-                if (input.trim()) {
-                  sendMessage(input)
-                  setInput('')
-                }
-              }}
-            >
-              <div className="relative">
-                <textarea
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  placeholder="Type your message..."
-                  className="demo-textarea pr-10 text-sm"
-                  rows={1}
-                  style={{ minHeight: '36px', maxHeight: '120px' }}
-                  onInput={(e) => {
-                    const target = e.target as HTMLTextAreaElement
-                    target.style.height = 'auto'
-                    target.style.height =
-                      Math.min(target.scrollHeight, 120) + 'px'
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey && input.trim()) {
-                      e.preventDefault()
-                      sendMessage(input)
-                      setInput('')
-                    }
-                  }}
-                />
-                <button
-                  type="submit"
-                  disabled={!input.trim()}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 text-[var(--lagoon-deep)] transition-colors hover:text-[var(--sea-ink)] disabled:text-[var(--sea-ink-soft)]"
-                >
-                  <Send className="w-4 h-4" />
-                </button>
-              </div>
-            </form>
-          </div>
+          <chat.AppChat />
         </div>
       )}
     </div>

--- a/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/demo-ai-hook.ts
+++ b/packages/create/src/frameworks/react/add-ons/ai/assets/src/lib/demo-ai-hook.ts
@@ -1,8 +1,4 @@
-import {
-  fetchServerSentEvents,
-  useChat,
-  createChatClientOptions,
-} from '@tanstack/ai-react'
+import { fetchServerSentEvents, useChat } from '@tanstack/ai-react'
 import type { InferChatMessages } from '@tanstack/ai-react'
 import { clientTools } from '@tanstack/ai-client'
 
@@ -12,10 +8,13 @@ const recommendGuitarToolClient = recommendGuitarToolDef.client(({ id }) => ({
   id: +id,
 }))
 
-const chatOptions = createChatClientOptions({
+// A plain options object (rather than `createChatClientOptions`) so the
+// `@tanstack/ai-react/ui` type helpers can structurally read `tools` and
+// infer the named tools for the chat hook registry.
+export const chatOptions = {
   connection: fetchServerSentEvents('/demo/api/ai/chat'),
   tools: clientTools(recommendGuitarToolClient),
-})
+}
 
 export type ChatMessages = InferChatMessages<typeof chatOptions>
 


### PR DESCRIPTION
## What

Migrates the React **AI add-on**'s floating "AI Assistant" widget from the older `useChat` / `createChatClientOptions` API (with hand-rolled message rendering) to the newer **`@tanstack/ai-react/ui` `createChatHook` registry** pattern, matching the `ts-react-ui-chatbot` reference example.

## Changes

- **New** `components/ai/demo-ai-ui-context.ts` — `createChatHookContexts()` (scoped chat/part/interrupt contexts).
- **New** `components/ai/demo-chat-registry.tsx` — `createChatHook({...})` registering `layout`/`message`/`input` chrome plus a `text` part and the `recommendGuitar` tool component. Styled with the existing `demo-*` / `--sea-ink` design tokens (no new dependencies; reuses `Streamdown`).
- **`components/demo-AIAssistant.tsx`** — renders the panel via `<chat.AppChat />` instead of a bespoke `Messages` list + textarea form. Keeps the `showAIAssistant` store used by the guitar card.
- **`lib/demo-ai-hook.ts`** — exports a **plain** options object instead of wrapping in `createChatClientOptions`, so the `@tanstack/ai-react/ui` type helpers can structurally infer the named tools (the wrapper hid `tools`, resolving the tool part type to `never`). The existing `ai-chat.tsx` route + `InferChatMessages` still compile.

## Scope

- Only the floating **AI Assistant** surface is migrated. The full-page `ai-chat.tsx` route is intentionally left on the current hook.
- Guitar-recommendation domain, behaviour, and styling are unchanged.

## Verification

- Scaffolded an app with `--add-ons ai` against the published `@tanstack/ai-react@0.24.0`: my files typecheck clean.
- Live-tested in the browser end-to-end: the assistant panel mounts, streams a response, and renders the `recommendGuitar` guitar card through the new tool component.
- Full pre-commit suite (`pnpm build && pnpm test`, incl. e2e add-on smoke tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the AI Assistant’s chat interface while preserving its existing appearance and behavior.
  - Chat messages, markdown content, input controls, scrolling, and error displays continue to work consistently.
  - Guitar recommendations remain displayed inline as interactive cards.
  - The assistant’s open and close controls remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->